### PR TITLE
Fix tests for gazetteer changes

### DIFF
--- a/geoparser/gazetteer.py
+++ b/geoparser/gazetteer.py
@@ -18,6 +18,10 @@ from geoparser.config.models import GazetteerData
 
 class Gazetteer(ABC):
 
+    @abstractmethod
+    def create_location_description(self, location: dict[str, str]) -> str:
+        pass
+
     def get_location_description(
         self, location: dict[str, t.Union[int, str, float]]
     ) -> str:
@@ -342,8 +346,6 @@ class LocalDBGazetteer(Gazetteer):
     def query_candidates(
         self,
         toponym: str,
-        country_filter: list[str] = None,
-        feature_filter: list[str] = None,
     ) -> list[int]:
 
         location_identifier = self.config.location_identifier

--- a/geoparser/geoparser.py
+++ b/geoparser/geoparser.py
@@ -19,14 +19,10 @@ class Geoparser:
         spacy_model: str = "en_core_web_trf",
         transformer_model: str = "dguzh/geo-all-distilroberta-v1",
         gazetteer: str = "geonames",
-        country_filter: list[str] = None,
-        feature_filter: list[str] = None,
     ):
         self.gazetteer = self.setup_gazetteer(gazetteer)
         self.nlp = self.setup_spacy(spacy_model)
         self.transformer = self.setup_transformer(transformer_model)
-        self.country_filter = country_filter
-        self.feature_filter = feature_filter
 
     def setup_gazetteer(self, gazetteer: str) -> type[Gazetteer]:
 

--- a/geoparser/geospan.py
+++ b/geoparser/geospan.py
@@ -20,11 +20,7 @@ class GeoSpan(Span):
 
     @property
     def candidates(self) -> list[int]:
-        return self.doc.geoparser.gazetteer.query_candidates(
-            self.text,
-            self.doc.geoparser.country_filter,
-            self.doc.geoparser.feature_filter,
-        )
+        return self.doc.geoparser.gazetteer.query_candidates(self.text)
 
     @property
     def context(self):

--- a/geoparser/swissnames3d.py
+++ b/geoparser/swissnames3d.py
@@ -12,7 +12,7 @@ class SwissNames3D(LocalDBGazetteer):
     def __init__(self):
         super().__init__("swissnames3d")
 
-    def create_location_description(self, location):
+    def create_location_description(self, location: dict[str, str]) -> str:
         name = location["NAME"] or ""
         objektart = f' ({location["OBJEKTART"]})' if location["OBJEKTART"] else ""
 

--- a/geoparser/tests/conftest.py
+++ b/geoparser/tests/conftest.py
@@ -37,6 +37,13 @@ def geonames_real_data() -> GeoNames:
     gazetteer.db_path = str(tmpdir / Path(gazetteer.db_path).name)
     for dataset in gazetteer.config.data:
         gazetteer.load_data(dataset)
+    gazetteer.create_names_table()
+    gazetteer.populate_names_table()
+    gazetteer.create_names_fts_table()
+    gazetteer.populate_names_fts_table()
+    gazetteer.create_locations_table()
+    gazetteer.populate_locations_table()
+    gazetteer.drop_redundant_tables()
     return gazetteer
 
 

--- a/geoparser/tests/static/gazetteers_config_invalid.yaml
+++ b/geoparser/tests/static/gazetteers_config_invalid.yaml
@@ -1,3 +1,2 @@
-- name: test_gazetteer
-  data:
-  - name: invalid
+- name: test-invalid
+  location_identifier: 12

--- a/geoparser/tests/static/gazetteers_config_valid.yaml
+++ b/geoparser/tests/static/gazetteers_config_valid.yaml
@@ -1,27 +1,49 @@
-- name: test_gazetteer
+- name: test-full
+  location_identifier: testid
+  location_columns:
+  - name: testid
+    type: INTEGER
+    primary: true
+  - name: testname
+    type: TEXT
   data:
-  - name: full
-    url: https://test.test.org/path/to/file.zip
-    extracted_file: file.txt
-    skiprows: 50
+  - name: data1
+    url: https://data1.org/path/to/data1.zip
+    extracted_files:
+    - data1.txt
     columns:
-    - name: col1
+    - name: testid
       type: INTEGER
       primary: true
-    - name: col2
+    - name: testname
       type: TEXT
-    virtual_tables:
-    - name: virtual1
-      using: fts5
-      args:
-      - col2
-      kwargs:
-        content: full
-        content_rowid: col1
-        tokenize: "unicode61 tokenchars '.'"
-  - name: minimal
-    url: https://test.test.org/path/to/file.zip
-    extracted_file: file.txt
+    skiprows: 50
+  - name: data2
+    url: https://data2.org/path/to/data2.zip
+    extracted_files:
+    - data2.txt
     columns:
-    - name: col1
+    - name: testcode
+      type: TEXT
+      primary: true
+    - name: testname
+      type: TEXT
+    toponym_columns:
+    - name: testminimal
+    - name: testseparator
+      separator: ","
+- name: test-minimal
+  location_identifier: testid
+  location_columns:
+  - name: testid
+    type: INTEGER
+    primary: true
+  data:
+  - name: data1
+    url: https://data1.org/path/to/data1.zip
+    extracted_files:
+    - data1.txt
+    columns:
+    - name: testid
       type: INTEGER
+      primary: true

--- a/geoparser/tests/test_config.py
+++ b/geoparser/tests/test_config.py
@@ -2,7 +2,12 @@ import pydantic
 import pytest
 
 from geoparser.config import get_gazetteer_configs
-from geoparser.config.models import Column, GazetteerConfig, GazetteerData, VirtualTable
+from geoparser.config.models import (
+    Column,
+    GazetteerConfig,
+    GazetteerData,
+    ToponymColumn,
+)
 from geoparser.tests.utils import get_static_test_file
 
 
@@ -12,39 +17,52 @@ def test_get_gazetteer_configs_valid(monkeypatch):
         lambda _: get_static_test_file("gazetteers_config_valid.yaml"),
     )
     expected = {
-        "test_gazetteer": GazetteerConfig(
-            name="test_gazetteer",
+        "test-full": GazetteerConfig(
+            name="test-full",
+            location_identifier="testid",
+            location_columns=[
+                Column(name="testid", type="INTEGER", primary=True),
+                Column(name="testname", type="TEXT"),
+            ],
             data=[
                 GazetteerData(
-                    name="full",
-                    url="https://test.test.org/path/to/file.zip",
-                    extracted_file="file.txt",
-                    skiprows=50,
+                    name="data1",
+                    url="https://data1.org/path/to/data1.zip",
+                    extracted_files=["data1.txt"],
                     columns=[
-                        Column(name="col1", type="INTEGER", primary=True),
-                        Column(name="col2", type="TEXT"),
+                        Column(name="testid", type="INTEGER", primary=True),
+                        Column(name="testname", type="TEXT"),
                     ],
-                    virtual_tables=[
-                        VirtualTable(
-                            name="virtual1",
-                            using="fts5",
-                            args=["col2"],
-                            kwargs={
-                                "content": "full",
-                                "content_rowid": "col1",
-                                "tokenize": "unicode61 tokenchars '.'",
-                            },
-                        )
-                    ],
+                    skiprows=50,
                 ),
                 GazetteerData(
-                    name="minimal",
-                    url="https://test.test.org/path/to/file.zip",
-                    extracted_file="file.txt",
-                    columns=[Column(name="col1", type="INTEGER")],
+                    name="data2",
+                    url="https://data2.org/path/to/data2.zip",
+                    extracted_files=["data2.txt"],
+                    columns=[
+                        Column(name="testcode", type="TEXT", primary=True),
+                        Column(name="testname", type="TEXT"),
+                    ],
+                    toponym_columns=[
+                        ToponymColumn(name="testminimal"),
+                        ToponymColumn(name="testseparator", separator=","),
+                    ],
                 ),
             ],
-        )
+        ),
+        "test-minimal": GazetteerConfig(
+            name="test-minimal",
+            location_identifier="testid",
+            location_columns=[Column(name="testid", type="INTEGER", primary=True)],
+            data=[
+                GazetteerData(
+                    name="data1",
+                    url="https://data1.org/path/to/data1.zip",
+                    extracted_files=["data1.txt"],
+                    columns=[Column(name="testid", type="INTEGER", primary=True)],
+                ),
+            ],
+        ),
     }
     actual = get_gazetteer_configs()
     assert actual == expected

--- a/geoparser/tests/test_gazetteer.py
+++ b/geoparser/tests/test_gazetteer.py
@@ -1,8 +1,5 @@
-import re
 import sqlite3
 import tempfile
-import types
-import typing as t
 from pathlib import Path
 
 import pandas as pd
@@ -10,14 +7,9 @@ import py
 import pytest
 from requests_mock.mocker import Mocker
 
-from geoparser.gazetteer import Gazetteer, LocalDBGazetteer
+from geoparser.config.models import Column, GazetteerData
+from geoparser.gazetteer import LocalDBGazetteer
 from geoparser.tests.utils import get_static_test_file, make_concrete
-
-
-@pytest.fixture(scope="session")
-def gazetteer() -> Gazetteer:
-    gazetteer = make_concrete(Gazetteer)()
-    return gazetteer
 
 
 @pytest.fixture(scope="function")
@@ -26,295 +18,12 @@ def localdb_gazetteer(monkeypatch) -> LocalDBGazetteer:
         "geoparser.config.config.get_config_file",
         lambda _: get_static_test_file("gazetteers_config_valid.yaml"),
     )
-    localdb_gazetteer = make_concrete(LocalDBGazetteer)(db_name="test_gazetteer")
+    localdb_gazetteer = make_concrete(LocalDBGazetteer)(gazetteer_name="test-full")
     tmpdir = py.path.local(tempfile.mkdtemp())
     localdb_gazetteer.data_dir = str(tmpdir)
     localdb_gazetteer.db_path = str(tmpdir / Path(localdb_gazetteer.db_path).name)
     localdb_gazetteer.clean_dir()
     return localdb_gazetteer
-
-
-@pytest.mark.parametrize(
-    "template,location,expected",
-    [
-        (  # base case
-            "<name>",
-            {"name": "Geneva"},
-            "Geneva",
-        ),
-        (  # multiple placeholders
-            "<name>, <country_name>",
-            {"name": "Geneva", "country_name": "Switzerland"},
-            "Geneva, Switzerland",
-        ),
-        (  # non-ascii placeholder name
-            "<XÆA12>",
-            {"XÆA12": "Geneva"},
-            "Geneva",
-        ),
-        (  # placeholder cannot contain whitespace
-            "<X Æ A 12>",
-            {"X Æ A 12": "Geneva"},
-            "<X Æ A 12>",
-        ),
-        (  # remove placeholders with no value in location
-            "<name>, <admin2_name>, <admin1_name>, <country_name>",
-            {"name": "Geneva", "country_name": "Switzerland"},
-            "Geneva, Switzerland",
-        ),
-        (  # no placeholder
-            "I am a fish",
-            {"name": "Geneva", "country_name": "Switzerland"},
-            "I am a fish",
-        ),
-        (  # empty string
-            "",
-            {"name": "Geneva", "country_name": "Switzerland"},
-            "",
-        ),
-        (  # empty location returns None
-            "",
-            {},
-            None,
-        ),
-    ],
-)
-def test_get_location_description_base(
-    gazetteer: Gazetteer,
-    template: str,
-    location: dict[str, str],
-    expected: t.Optional[str],
-):
-    gazetteer.location_description_template = template
-    assert gazetteer.get_location_description(location) == expected
-
-
-@pytest.mark.parametrize(
-    "template,location,expected",
-    [
-        (  # one value
-            "COND[in, any{<admin2_name>, <admin1_name>, <country_name>}]",
-            {"admin2_name": "Geneva"},
-            "in",
-        ),
-        (  # all values
-            "COND[in, any{<admin2_name>, <admin1_name>, <country_name>}]",
-            {
-                "admin2_name": "Geneva",
-                "admin1_name": "Geneva",
-                "country_name": "Switzerland",
-            },
-            "in",
-        ),
-        (  # no values
-            "COND[in, any{<admin2_name>, <admin1_name>, <country_name>}]",
-            {
-                "admin3_name": "Geneva",
-            },
-            "",
-        ),
-    ],
-)
-def test_get_location_description_any(
-    gazetteer: Gazetteer,
-    template: str,
-    location: dict[str, str],
-    expected: t.Optional[str],
-):
-    gazetteer.location_description_template = template
-    assert gazetteer.get_location_description(location) == expected
-
-
-@pytest.mark.parametrize(
-    "template,location,expected",
-    [
-        (  # one value
-            "COND[in, all{<admin2_name>, <admin1_name>, <country_name>}]",
-            {"admin2_name": "Geneva"},
-            "",
-        ),
-        (  # all values
-            "COND[in, all{<admin2_name>, <admin1_name>, <country_name>}]",
-            {
-                "admin2_name": "Geneva",
-                "admin1_name": "Geneva",
-                "country_name": "Switzerland",
-            },
-            "in",
-        ),
-        (  # no values
-            "COND[in, all{<admin2_name>, <admin1_name>, <country_name>}]",
-            {
-                "admin3_name": "Geneva",
-            },
-            "",
-        ),
-    ],
-)
-def test_get_location_description_all(
-    gazetteer: Gazetteer,
-    template: str,
-    location: dict[str, str],
-    expected: t.Optional[str],
-):
-    gazetteer.location_description_template = template
-    assert gazetteer.get_location_description(location) == expected
-
-
-@pytest.mark.parametrize(
-    "cond_expr",
-    [
-        "COND[in, sorted{<admin2_name>, <admin1_name>, <country_name>}]",  # not a supported function
-        "<country_name>}",  # no condition
-        "",  # empty string
-    ],
-)
-def test_evaluate_conditionals_no_condition(
-    gazetteer: Gazetteer,
-    cond_expr: str,
-):
-    assert gazetteer.evaluate_conditionals(cond_expr) == (None, None)
-
-
-@pytest.mark.parametrize(
-    "cond_expr,pos,neg",
-    [
-        (  # all
-            "COND[in, all{<admin2_name>, <admin1_name>, <country_name>}]",
-            {
-                "admin2_name": "Geneva",
-                "admin1_name": "Geneva",
-                "country_name": "Switzerland",
-            },
-            {
-                "admin1_name": "Geneva",
-                "country_name": "Switzerland",
-            },
-        ),
-        (  # any
-            "COND[in, any{<admin2_name>, <admin1_name>, <country_name>}]",
-            {
-                "admin2_name": "Geneva",
-                "admin1_name": "Geneva",
-                "country_name": "Switzerland",
-            },
-            {
-                "asdf": "Geneva",
-                "adsf": "Switzerland",
-            },
-        ),
-    ],
-)
-def test_evaluate_conditionals_valid(
-    gazetteer: Gazetteer,
-    cond_expr: str,
-    pos: dict[str, str],
-    neg: dict[str, str],
-):
-    text, conditional_func = gazetteer.evaluate_conditionals(cond_expr)
-    assert type(text) is str
-    assert type(conditional_func) is types.FunctionType
-    assert conditional_func(pos) is True
-    assert conditional_func(neg) is False
-
-
-@pytest.mark.parametrize(
-    "template,location,expected",
-    [
-        (  # base case
-            "COND[in, any{<admin2_name>, <admin1_name>, <country_name>}]",
-            {"admin2_name": "Geneva"},
-            "in",
-        ),
-        (  # does not substitute anything else
-            "asdfCOND[in, any{<admin2_name>, <admin1_name>, <country_name>}]asdf",
-            {
-                "admin2_name": "Geneva",
-                "admin1_name": "Geneva",
-                "country_name": "Switzerland",
-            },
-            "asdfinasdf",
-        ),
-        (  # no conditional
-            "asdf",
-            {
-                "admin3_name": "Geneva",
-            },
-            "asdf",
-        ),
-        (  # empty string
-            "",
-            {
-                "admin3_name": "Geneva",
-            },
-            "",
-        ),
-        (  # empty location
-            "asdf",
-            {},
-            "asdf",
-        ),
-    ],
-)
-def test_substitute_conditionals(
-    gazetteer: Gazetteer,
-    template: str,
-    location: dict[str, str],
-    expected: t.Optional[str],
-):
-    assert gazetteer.substitute_conditionals(location, template) == expected
-
-
-@pytest.mark.parametrize(
-    "template,location,expected",
-    [
-        (  # base case
-            "COND[in, any{<admin2_name>, <admin1_name>, <country_name>}]",
-            {"admin2_name": "Geneva"},
-            "in",
-        ),
-        (  # does not substitute anything else
-            "asdfCOND[in, any{<admin2_name>, <admin1_name>, <country_name>}]asdf",
-            {
-                "admin2_name": "Geneva",
-                "admin1_name": "Geneva",
-                "country_name": "Switzerland",
-            },
-            "asdfinasdf",
-        ),
-        (  # no conditional
-            "asdf",
-            {
-                "admin3_name": "Geneva",
-            },
-            "asdf",
-        ),
-        (  # empty string
-            "",
-            {
-                "admin3_name": "Geneva",
-            },
-            "",
-        ),
-        (  # empty location
-            "asdf",
-            {},
-            "asdf",
-        ),
-        (  # empty template
-            "",
-            {"admin2_name": "Geneva"},
-            "",
-        ),
-    ],
-)
-def test_format_location_description(
-    gazetteer: Gazetteer,
-    template: str,
-    location: dict[str, str],
-    expected: t.Optional[str],
-):
-    assert gazetteer.substitute_conditionals(location, template) == expected
 
 
 @pytest.mark.parametrize("keep_db", [True, False])
@@ -343,26 +52,36 @@ def test_clean_dir(localdb_gazetteer: LocalDBGazetteer, keep_db: bool):
 
 
 @pytest.mark.parametrize(
-    "url, filename",
+    "dataset",
     [
-        ("https://my.url.org/path/to/a.txt", "a.txt"),
-        ("https://my.url.org/path/to/b.zip", "b.zip"),
+        GazetteerData(
+            name="a",
+            url="https://my.url.org/path/to/a.txt",
+            extracted_files=["a.txt"],
+            columns=[Column(name="", type="")],
+        ),
+        GazetteerData(
+            name="b",
+            url="https://my.url.org/path/to/b.zip",
+            extracted_files=["b.txt"],
+            columns=[Column(name="", type="")],
+        ),
     ],
 )
 def test_download_file(
     localdb_gazetteer: LocalDBGazetteer,
-    url: str,
-    filename: str,
+    dataset: GazetteerData,
     requests_mock: Mocker,
 ):
-    print(type(requests_mock))
-    with open(get_static_test_file(filename), "rb") as file:
-        requests_mock.get(url, body=file)
-        localdb_gazetteer.download_file(url=url)
+    raw_file = dataset.url.split("/")[-1]
+    with open(get_static_test_file(raw_file), "rb") as file:
+        requests_mock.get(dataset.url, body=file)
+        localdb_gazetteer.download_file(dataset=dataset)
     dir_content = Path(localdb_gazetteer.db_path).parent.glob("**/*")
     files = [content.name for content in dir_content]
-    # a.txt downloaded as is, b.zip has been extracted
-    assert files == [re.sub("zip", "txt", filename)]
+    # a.txt downloaded as is, b.zip has been extracted and is still around
+    zipfile = [raw_file] if raw_file.endswith(".zip") else []
+    assert sorted(files) == sorted(dataset.extracted_files + zipfile)
 
 
 def test_initiate_connection(localdb_gazetteer: LocalDBGazetteer):
@@ -383,134 +102,9 @@ def test_get_cursor(localdb_gazetteer: LocalDBGazetteer):
     assert type(localdb_gazetteer._get_cursor()) == sqlite3.Cursor
 
 
-def test_create_table(localdb_gazetteer: LocalDBGazetteer):
-    dataset = localdb_gazetteer.config.data[0]
-    localdb_gazetteer._create_table(dataset)
-    localdb_gazetteer._initiate_connection()
-    query = "SELECT name FROM sqlite_master WHERE type='table'"
-    cursor = localdb_gazetteer._get_cursor()
-    tables = [table for table in cursor.execute(query).fetchall()[0]]
-    assert [dataset.name] == tables
-
-
-def test_create_virtual_table(localdb_gazetteer: LocalDBGazetteer):
-    dataset = localdb_gazetteer.config.data[0]
-    localdb_gazetteer._create_virtual_table(dataset.virtual_tables[0])
-    localdb_gazetteer._initiate_connection()
-    query = "SELECT name FROM sqlite_master WHERE type='table' AND sql LIKE 'CREATE VIRTUAL TABLE%'"
-    cursor = localdb_gazetteer._get_cursor()
-    tables = [table for table in cursor.execute(query).fetchall()[0]]
-    assert [dataset.virtual_tables[0].name] == tables
-
-
-def test_create_tables(localdb_gazetteer: LocalDBGazetteer):
-    dataset = localdb_gazetteer.config.data[0]
-    localdb_gazetteer.create_tables(dataset)
-    localdb_gazetteer._initiate_connection()
-    tables_query = "SELECT name FROM sqlite_master WHERE type='table'"
-    virtual_tables_query = "SELECT name FROM sqlite_master WHERE type='table' AND sql LIKE 'CREATE VIRTUAL TABLE%'"
-    cursor = localdb_gazetteer._get_cursor()
-    tables = [table for table in cursor.execute(tables_query).fetchall()[0]]
-    virtual_tables = [
-        table for table in cursor.execute(virtual_tables_query).fetchall()[0]
-    ]
-    assert [dataset.name] == tables
-    assert [dataset.virtual_tables[0].name] == virtual_tables
-
-
-def test_load_file_into_table(
-    monkeypatch, localdb_gazetteer: LocalDBGazetteer, test_chunk_full: pd.DataFrame
-):
-    monkeypatch.setattr(
-        LocalDBGazetteer,
-        "read_file",
-        lambda *_: [test_chunk_full],
-    )
-    dataset = localdb_gazetteer.config.data[0]
-    localdb_gazetteer.create_tables(dataset)
-    localdb_gazetteer.load_file_into_table(
-        get_static_test_file("a.txt"),  # just needed for line count
-        dataset.name,
-        ["col1", "col2"],
-    )
-    localdb_gazetteer._initiate_connection()
-    content_query = f"SELECT * FROM {dataset.name}"
-    cursor = localdb_gazetteer._get_cursor()
-    content = cursor.execute(content_query).fetchall()
-    assert content == [tuple(row) for row in test_chunk_full.values.tolist()]
-
-
-def test_populate_virtual_table(
-    monkeypatch, localdb_gazetteer: LocalDBGazetteer, test_chunk_full: pd.DataFrame
-):
-    monkeypatch.setattr(
-        LocalDBGazetteer,
-        "read_file",
-        lambda *_: [test_chunk_full],
-    )
-    dataset = localdb_gazetteer.config.data[0]
-    localdb_gazetteer.create_tables(dataset)
-    localdb_gazetteer.load_file_into_table(
-        get_static_test_file("a.txt"),  # just needed for line count
-        dataset.name,
-        ["col1", "col2"],
-    )
-    localdb_gazetteer.populate_virtual_table(dataset.virtual_tables[0], dataset.name)
-    localdb_gazetteer._initiate_connection()
-    content_query = f"SELECT * FROM {dataset.virtual_tables[0].name}"
-    cursor = localdb_gazetteer._get_cursor()
-    content = cursor.execute(content_query).fetchall()
-    assert content == [(value,) for value in test_chunk_full["col2"].to_list()]
-
-
-def test_populate_tables(
-    monkeypatch, localdb_gazetteer: LocalDBGazetteer, test_chunk_full: pd.DataFrame
-):
-    monkeypatch.setattr(
-        LocalDBGazetteer,
-        "read_file",
-        lambda *_: [test_chunk_full],
-    )
-    dataset = localdb_gazetteer.config.data[0]
-    localdb_gazetteer.create_tables(dataset)
-    with open(Path(localdb_gazetteer.data_dir) / dataset.extracted_file, "w"):
-        pass
-    localdb_gazetteer.populate_tables(dataset)
-    localdb_gazetteer._initiate_connection()
-    content_query_full = f"SELECT * FROM {dataset.name}"
-    content_query_virtual = f"SELECT * FROM {dataset.virtual_tables[0].name}"
-    cursor = localdb_gazetteer._get_cursor()
-    content_full = cursor.execute(content_query_full).fetchall()
-    content_virtual = cursor.execute(content_query_virtual).fetchall()
-    assert content_full == [tuple(row) for row in test_chunk_full.values.tolist()]
-    assert content_virtual == [(value,) for value in test_chunk_full["col2"].to_list()]
-
-
-def test_load_data(
-    monkeypatch, localdb_gazetteer: LocalDBGazetteer, test_chunk_full: pd.DataFrame
-):
-    monkeypatch.setattr(
-        LocalDBGazetteer,
-        "read_file",
-        lambda *_: [test_chunk_full],
-    )
-    dataset = localdb_gazetteer.config.data[0]
-    with open(Path(localdb_gazetteer.data_dir) / dataset.extracted_file, "w"):
-        pass
-    localdb_gazetteer.load_data(dataset)
-    localdb_gazetteer._initiate_connection()
-    content_query_full = f"SELECT * FROM {dataset.name}"
-    content_query_virtual = f"SELECT * FROM {dataset.virtual_tables[0].name}"
-    cursor = localdb_gazetteer._get_cursor()
-    content_full = cursor.execute(content_query_full).fetchall()
-    content_virtual = cursor.execute(content_query_virtual).fetchall()
-    assert content_full == [tuple(row) for row in test_chunk_full.values.tolist()]
-    assert content_virtual == [(value,) for value in test_chunk_full["col2"].to_list()]
-
-
 def test_execute_query(localdb_gazetteer: LocalDBGazetteer):
-    dataset = localdb_gazetteer.config.data[0]
-    localdb_gazetteer._create_table(dataset)
-    query = "SELECT name FROM sqlite_master"
-    tables = [table for table in localdb_gazetteer.execute_query(query)[0]]
-    assert [dataset.name] == tables
+    query1 = "CREATE TABLE IF NOT EXISTS asdf (asdf TEXT)"
+    query2 = "SELECT name FROM sqlite_master"
+    localdb_gazetteer.execute_query(query1)
+    tables = [table for table in localdb_gazetteer.execute_query(query2)[0]]
+    assert ["asdf"] == tables

--- a/geoparser/tests/test_geodoc.py
+++ b/geoparser/tests/test_geodoc.py
@@ -16,17 +16,17 @@ def test_locations_repr(locations: Locations):
     assert (
         locations.__repr__() == "[{'geonameid': 3039328, "
         "'name': 'Radio Andorra', "
+        "'feature_type': 'radio station', "
+        "'latitude': 42.5282, "
+        "'longitude': 1.57089, "
+        "'elevation': None, "
+        "'population': 0, "
         "'admin2_geonameid': None, "
         "'admin2_name': None, "
         "'admin1_geonameid': 3040684, "
         "'admin1_name': 'Encamp', "
         "'country_geonameid': 3041565, "
-        "'country_name': 'Andorra', "
-        "'feature_name': 'radio station', "
-        "'latitude': 42.5282, "
-        "'longitude': 1.57089, "
-        "'elevation': None, "
-        "'population': 0}]"
+        "'country_name': 'Andorra'}]"
     )
 
 

--- a/geoparser/tests/test_geonames.py
+++ b/geoparser/tests/test_geonames.py
@@ -21,89 +21,10 @@ def geonames() -> GeoNames:
 
 def test_read_file(geonames: GeoNames, test_chunk_full: pd.DataFrame):
     test_chunk_full["col1"] = test_chunk_full["col1"].astype(str)
-    file_content = [
-        df
-        for df in geonames.read_file(
-            get_static_test_file("test.tsv"),
-            ["col1", "col2"],
-        )
-    ]
-    assert file_content[0].equals(test_chunk_full)
-
-
-def test_read_tsv(geonames: GeoNames, test_chunk_full: pd.DataFrame):
-    test_chunk_full["col1"] = test_chunk_full["col1"].astype(str)
-    file_content = [
-        df
-        for df in geonames.read_tsv(
-            get_static_test_file("test.tsv"),
-            ["col1", "col2"],
-        )
-    ]
-    assert file_content[0].equals(test_chunk_full)
-
-
-@pytest.mark.parametrize(
-    "toponym,country_filter,feature_filter,expected",
-    [
-        ("Roc Meler", None, None, [2994701]),  # exists in data
-        ("Roc Meler", ["AD"], None, [2994701]),  # country filter OK (single)
-        ("Roc Meler", ["AD", "UZ"], None, [2994701]),  # country filter OK (multiple)
-        ("Roc Meler", ["UZ"], None, []),  # country filter NOK
-        ("Roc Meler", None, ["T"], [2994701]),  # feature filter OK (single)
-        (
-            "Roc Meler",
-            None,
-            ["T", "V"],
-            [2994701],
-        ),  # feature filter OK (multiple)
-        ("Roc Meler", None, ["V"], []),  # feature filter NOK
-    ],
-)
-def test_query_candidates(
-    geonames_real_data: GeoNames,
-    toponym: str,
-    country_filter: t.Optional[list[str]],
-    feature_filter: t.Optional[list[str]],
-    expected: list[int],
-):
-    candidates = geonames_real_data.query_candidates(
-        toponym, country_filter=country_filter, feature_filter=feature_filter
+    file_content, n_chunks = geonames.read_file(
+        get_static_test_file("test.tsv"),
+        ["col1", "col2"],
     )
-    assert candidates == expected
-
-
-@pytest.mark.parametrize(
-    "location_ids,expected",
-    [
-        (  # location_id in db
-            [2994701],
-            [
-                {
-                    "geonameid": 2994701,
-                    "name": "Roc Meler",
-                    "admin2_geonameid": None,
-                    "admin2_name": None,
-                    "admin1_geonameid": 3041203,
-                    "admin1_name": "Canillo",
-                    "country_geonameid": 3041565,
-                    "country_name": "Andorra",
-                    "feature_name": "peak",
-                    "latitude": 42.58765,
-                    "longitude": 1.7418,
-                    "elevation": 2811,
-                    "population": 0,
-                }
-            ],
-        ),
-        ([1], [None]),  # location_id not in db
-    ],
-)
-def test_query_location_info(
-    geonames_real_data: GeoNames,
-    location_ids: list[int],
-    expected: list[dict],
-):
-    info = geonames_real_data.query_location_info(location_ids=location_ids)
-    for actual, expected in zip(info, expected):
-        assert actual == expected
+    file_content = list(file_content)
+    assert len(file_content) == n_chunks
+    assert file_content[0].equals(test_chunk_full)

--- a/geoparser/tests/test_geoparser.py
+++ b/geoparser/tests/test_geoparser.py
@@ -99,7 +99,6 @@ def test_recognize(geoparser_real_data: Geoparser, texts):
 
 def test_get_candidate_ids(
     geoparser_real_data: Geoparser,
-    geonames_real_data: GeoNames,
     geodocs: list[GeoDoc],
     radio_andorra_id: int,
 ):

--- a/geoparser/tests/test_geospan.py
+++ b/geoparser/tests/test_geospan.py
@@ -101,7 +101,7 @@ def test_geospan_location(first_geodoc: GeoDoc):
         "admin1_name": "Encamp",
         "country_geonameid": 3041565,
         "country_name": "Andorra",
-        "feature_name": "radio station",
+        "feature_type": "radio station",
         "latitude": 42.5282,
         "longitude": 1.57089,
         "elevation": None,

--- a/geoparser/tests/test_trainer.py
+++ b/geoparser/tests/test_trainer.py
@@ -260,7 +260,7 @@ def test_prepare_training_data(
     ):
         assert text == train_corpus[0].text
         candidates_labels = {
-            "Ordino (first-order administrative division) in Ordino, Andorra": 0,
+            "Ordino (first-order administrative division) in Andorra": 0,
             "Ordino (seat of a first-order administrative division) in Ordino, Andorra": 1,
         }
         assert candidates_labels[candidate_text] == label


### PR DESCRIPTION
This PR fixes the tests for the changes to the `Gazetteer` classes.

**Tests fixed:**
- config
- gazetteer
- geodoc
- geonames
- geospan
- trainer

**Tests removed for the moment (new functionality is uncovered):**
- location description (`Gazetteer` subclasses)
- table creation/population, query_candidates, query_location_info (`LocalDBGazetteer`)
