### PR TITLE
Store thread-local data per instance for Gazetteer

### DIFF
--- a/geoparser/gazetteer.py
+++ b/geoparser/gazetteer.py
@@ -30,13 +30,13 @@ class Gazetteer(ABC):
 
 
 class LocalDBGazetteer(Gazetteer):
-    _local = local()
 
     def __init__(self, gazetteer_name: str):
         super().__init__()
         self.data_dir = os.path.join(user_data_dir("geoparser", ""), gazetteer_name)
         self.db_path = os.path.join(self.data_dir, gazetteer_name + ".db")
         self.config = get_gazetteer_configs()[gazetteer_name]
+        self._local = local()
 
     def connect(func):
         def call(self, *args, **kwargs):

--- a/geoparser/tests/test_gazetteer.py
+++ b/geoparser/tests/test_gazetteer.py
@@ -101,7 +101,6 @@ def test_get_cursor(localdb_gazetteer: LocalDBGazetteer):
     assert type(localdb_gazetteer._get_cursor()) == sqlite3.Cursor
 
 
-@pytest.mark.xfail(reason="test not yet adapted for threading changes")
 def test_execute_query(localdb_gazetteer: LocalDBGazetteer):
     query1 = "CREATE TABLE IF NOT EXISTS asdf (asdf TEXT)"
     query2 = "SELECT name FROM sqlite_master"

--- a/geoparser/tests/test_gazetteer.py
+++ b/geoparser/tests/test_gazetteer.py
@@ -101,9 +101,10 @@ def test_get_cursor(localdb_gazetteer: LocalDBGazetteer):
     assert type(localdb_gazetteer._get_cursor()) == sqlite3.Cursor
 
 
-# def test_execute_query(localdb_gazetteer: LocalDBGazetteer):
-#     query1 = "CREATE TABLE IF NOT EXISTS asdf (asdf TEXT)"
-#     query2 = "SELECT name FROM sqlite_master"
-#     localdb_gazetteer.execute_query(query1)
-#     tables = [table for table in localdb_gazetteer.execute_query(query2)[0]]
-#     assert ["asdf"] == tables
+@pytest.mark.xfail(reason="test not yet adapted for threading changes")
+def test_execute_query(localdb_gazetteer: LocalDBGazetteer):
+    query1 = "CREATE TABLE IF NOT EXISTS asdf (asdf TEXT)"
+    query2 = "SELECT name FROM sqlite_master"
+    localdb_gazetteer.execute_query(query1)
+    tables = [table for table in localdb_gazetteer.execute_query(query2)[0]]
+    assert ["asdf"] == tables


### PR DESCRIPTION
This small PR changes the thread-local data in the `LocalDBGazetter` subclasses to an instance variable. This should not break the fix from 661e243a27f2d24857c686622e1312ce21c73438. But it will allow the commented-out test to pass and should be more robust in setups with multiple co-existing `LocalDBGazetter` instances.