### PR TITLE
Speed up GeoparserAnnotator initialization

### DIFF
--- a/geoparser/__main__.py
+++ b/geoparser/__main__.py
@@ -1,6 +1,6 @@
 import argparse
 
-from geoparser.constants import GAZETTEERS, MODES
+from geoparser.constants import DEFAULT_TRANSFORMER_MODEL, GAZETTEERS, MODES
 
 
 def parse_args() -> argparse.Namespace:
@@ -18,6 +18,12 @@ def parse_args() -> argparse.Namespace:
         nargs="?",
         help="Specify the gazetteer to set up (required for 'download' mode)",
     )
+    parser.add_argument(
+        "--transformer-model",
+        type=str,
+        default=DEFAULT_TRANSFORMER_MODEL,
+        help="Specify the transformer model in annotator mode",
+    )
     args = parser.parse_args()
     return args
 
@@ -32,7 +38,7 @@ def main(args: argparse.Namespace):
     elif args.mode == MODES["annotator"]:
         from geoparser.annotator import GeoparserAnnotator
 
-        annotator = GeoparserAnnotator()
+        annotator = GeoparserAnnotator(args.transformer_model)
         annotator.run()
     else:
         print(f"Unknown mode: {args.mode}")

--- a/geoparser/annotator.py
+++ b/geoparser/annotator.py
@@ -66,7 +66,7 @@ class GeoparserAnnotator(Geoparser):
                 selected_gazetteer = request.form.get("gazetteer")
                 selected_spacy_model = request.form.get("spacy_model")
 
-                # Re-initialize gazetteer and nlp with selected options
+                # Initialize gazetteer and nlp with selected options
                 self.gazetteer = self.setup_gazetteer(selected_gazetteer)
                 self.nlp = self.setup_spacy(selected_spacy_model)
 

--- a/geoparser/annotator.py
+++ b/geoparser/annotator.py
@@ -22,16 +22,14 @@ from markupsafe import Markup
 from spacy.util import get_installed_models
 from werkzeug.utils import secure_filename
 
-from geoparser.constants import GAZETTEERS
+from geoparser.constants import DEFAULT_TRANSFORMER_MODEL, GAZETTEERS
 from geoparser.geoparser import Geoparser
 
 
 class GeoparserAnnotator(Geoparser):
-    def __init__(self, *args, **kwargs):
-        # Do not initialize spacy model here
-        super().__init__(
-            transformer_model="dguzh/geo-all-MiniLM-L6-v2", *args, **kwargs
-        )
+    def __init__(self, transformer_model=DEFAULT_TRANSFORMER_MODEL, *args, **kwargs):
+        # Only initialize transformer_model here
+        self.transformer = self.setup_transformer(transformer_model)
         template_dir = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "templates")
         )

--- a/geoparser/constants.py
+++ b/geoparser/constants.py
@@ -1,6 +1,8 @@
 from geoparser.geonames import GeoNames
 from geoparser.swissnames3d import SwissNames3D
 
+DEFAULT_TRANSFORMER_MODEL = "dguzh/geo-all-distilroberta-v1"
+
 GAZETTEERS = {"geonames": GeoNames, "swissnames3d": SwissNames3D}
 MAX_ERROR = 20039  # half Earth's circumference in km
 MODES = {"download": "download", "annotator": "annotator"}

--- a/geoparser/geoparser.py
+++ b/geoparser/geoparser.py
@@ -5,7 +5,7 @@ import torch
 from sentence_transformers import SentenceTransformer, util
 from tqdm.auto import tqdm
 
-from geoparser.constants import GAZETTEERS
+from geoparser.constants import DEFAULT_TRANSFORMER_MODEL, GAZETTEERS
 from geoparser.gazetteer import Gazetteer
 from geoparser.geodoc import GeoDoc
 
@@ -17,7 +17,7 @@ class Geoparser:
     def __init__(
         self,
         spacy_model: str = "en_core_web_trf",
-        transformer_model: str = "dguzh/geo-all-distilroberta-v1",
+        transformer_model: str = DEFAULT_TRANSFORMER_MODEL,
         gazetteer: str = "geonames",
     ):
         self.gazetteer = self.setup_gazetteer(gazetteer)


### PR DESCRIPTION
This small PR speeds up the initialization of the `GeoparserAnnotator` by only initializing the transformer model on app startup. The gazetteer and the spacy models are not required at this point and can be initialized with the session. Additionally, this PR adds an optional cli argument for choosing an alternative transformer model.