### PR TITLE
Make test pass with locally installed en_core_web_trf

### DIFF
--- a/geoparser/tests/test_geoparser.py
+++ b/geoparser/tests/test_geoparser.py
@@ -23,7 +23,7 @@ def test_init_geoparser_gazetteers(gazetteer: str):
         )
 
 
-@pytest.mark.parametrize("spacy_model", ["en_core_web_sm", "en_core_web_trf"])
+@pytest.mark.parametrize("spacy_model", ["en_core_web_sm", "mk_core_news_sm"])
 def test_init_geoparser_spacy_model(spacy_model: str):
     # raises error if spacy model has not been installed yet
     with nullcontext() if spacy_model == "en_core_web_sm" else pytest.raises(OSError):


### PR DESCRIPTION
This small PR changes the tests to use the `mk_core_news_sm` as an example for a model that has not yet been installed. The previous `en_core_web_trf` model is often locally available as it is the recommended model for English for accuracy.
This makes tests fail locally, even though they pass in the GitHub actions. Tests will still fail if `mk_core_news_sm` is also locally available.