### PR TITLE
Set up multiple gazetteers with a single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,15 @@ These files are temporarily stored in your system's user-specific data directory
 
 Please ensure you have enough disk space available. The final size of the downloaded GeoNames data will be approximately 3.2 GB, increasing temporarily to around 5 GB during the download and setup process.
 
-**Note:** The library currently only supports the GeoNames gazetteer, but the framework allows for future extensions with other knowledge bases.
+#### Downloading multiple gazetteers
+
+You can use the same command mentioned above to set up multiple gazetteers:
+
+```bash
+python -m geoparser download geonames swissnames3d
+```
+
+
 
 ## Usage
 

--- a/geoparser/__main__.py
+++ b/geoparser/__main__.py
@@ -14,6 +14,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "gazetteer",
         type=str,
+        nargs="+",
         choices=GAZETTEERS.keys(),
         help="specify the gazetteer to set up",
     )
@@ -23,8 +24,9 @@ def parse_args() -> argparse.Namespace:
 
 def main(args: argparse.Namespace):
     if args.mode == MODES["download"]:
-        gazetteer = GAZETTEERS[args.gazetteer]()
-        gazetteer.setup_database()
+        for gazetteer_name in args.gazetteer:
+            gazetteer = GAZETTEERS[gazetteer_name]()
+            gazetteer.setup_database()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This small PR extends the cli-script to allow for setting up multiple gazetters with a single command. It changes the `gazetteer` arg to a list of strings, looping over all gazetteer names provided.