### PR TITLE
Refactor cli to make it more similar to spacy

### DIFF
--- a/geoparser/__main__.py
+++ b/geoparser/__main__.py
@@ -1,44 +1,27 @@
-import argparse
+import typer
 
-from geoparser.constants import GAZETTEERS, MODES
+from geoparser.annotator import GeoparserAnnotator
+from geoparser.constants import GAZETTEERS, GAZETTEERS_CHOICES
 
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "mode",
-        type=str,
-        choices=MODES.values(),
-        help="The setup mode for geoparser",
-    )
-    parser.add_argument(
-        "gazetteer",
-        type=str,
-        nargs="*",
-        choices=list(GAZETTEERS.keys()) + [[]],
-        help="Specify the gazetteer to set up (required for 'download' mode)",
-    )
-    args = parser.parse_args()
-    return args
+app = typer.Typer()
 
 
-def main(args: argparse.Namespace):
-    if args.mode == MODES["download"]:
-        if not args.gazetteer:
-            print("Error: 'gazetteer' argument is required for 'download' mode.")
-            exit(1)
-        for gazetteer_name in args.gazetteer:
-            gazetteer = GAZETTEERS[gazetteer_name]()
-            gazetteer.setup_database()
-    elif args.mode == MODES["annotator"]:
-        from geoparser.annotator import GeoparserAnnotator
+@app.command("download")
+def download_cli(gazetteers: list[GAZETTEERS_CHOICES]):
+    for gazetteer_name in gazetteers:
+        gazetteer = GAZETTEERS[gazetteer_name]()
+        gazetteer.setup_database()
 
-        annotator = GeoparserAnnotator()
-        annotator.run()
-    else:
-        print(f"Unknown mode: {args.mode}")
+
+@app.command("annotator")
+def annotator_cli():
+    annotator = GeoparserAnnotator()
+    annotator.run()
+
+
+def main():
+    app()
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    main(args)
+    main()

--- a/geoparser/constants.py
+++ b/geoparser/constants.py
@@ -11,7 +11,7 @@ class GAZETTEERS_CHOICES(str, Enum):
 
 DEFAULT_TRANSFORMER_MODEL = "dguzh/geo-all-distilroberta-v1"
 GAZETTEERS = {
-    GAZETTEERS_CHOICES.geonames: GeoNames,
-    GAZETTEERS_CHOICES.swissnames3d: SwissNames3D,
+    GAZETTEERS_CHOICES.geonames.value: GeoNames,
+    GAZETTEERS_CHOICES.swissnames3d.value: SwissNames3D,
 }
 MAX_ERROR = 20039  # half Earth's circumference in km

--- a/geoparser/constants.py
+++ b/geoparser/constants.py
@@ -1,8 +1,17 @@
+from enum import Enum
+
 from geoparser.geonames import GeoNames
 from geoparser.swissnames3d import SwissNames3D
 
-DEFAULT_TRANSFORMER_MODEL = "dguzh/geo-all-distilroberta-v1"
 
-GAZETTEERS = {"geonames": GeoNames, "swissnames3d": SwissNames3D}
+class GAZETTEERS_CHOICES(str, Enum):
+    geonames = "geonames"
+    swissnames3d = "swissnames3d"
+
+
+DEFAULT_TRANSFORMER_MODEL = "dguzh/geo-all-distilroberta-v1"
+GAZETTEERS = {
+    GAZETTEERS_CHOICES.geonames: GeoNames,
+    GAZETTEERS_CHOICES.swissnames3d: SwissNames3D,
+}
 MAX_ERROR = 20039  # half Earth's circumference in km
-MODES = {"download": "download", "annotator": "annotator"}

--- a/geoparser/tests/static/gazetteers_config_valid.yaml
+++ b/geoparser/tests/static/gazetteers_config_valid.yaml
@@ -1,5 +1,9 @@
 - name: test-full
   location_identifier: testid
+  location_coordinates:
+    x_column: longitude
+    y_column: latitude
+    crs: EPSG:4326
   location_columns:
   - name: testid
     type: TEXT
@@ -34,6 +38,10 @@
       separator: ","
 - name: test-minimal
   location_identifier: testid
+  location_coordinates:
+    x_column: longitude
+    y_column: latitude
+    crs: EPSG:4326
   location_columns:
   - name: testid
     type: TEXT

--- a/geoparser/tests/test_config.py
+++ b/geoparser/tests/test_config.py
@@ -6,6 +6,7 @@ from geoparser.config.models import (
     Column,
     GazetteerConfig,
     GazetteerData,
+    LocationCoordinates,
     ToponymColumn,
 )
 from geoparser.tests.utils import get_static_test_file
@@ -20,6 +21,9 @@ def test_get_gazetteer_configs_valid(monkeypatch):
         "test-full": GazetteerConfig(
             name="test-full",
             location_identifier="testid",
+            location_coordinates=LocationCoordinates(
+                x_column="longitude", y_column="latitude", crs="EPSG:4326"
+            ),
             location_columns=[
                 Column(name="testid", type="TEXT", primary=True),
                 Column(name="testname", type="TEXT"),
@@ -53,6 +57,9 @@ def test_get_gazetteer_configs_valid(monkeypatch):
         "test-minimal": GazetteerConfig(
             name="test-minimal",
             location_identifier="testid",
+            location_coordinates=LocationCoordinates(
+                x_column="longitude", y_column="latitude", crs="EPSG:4326"
+            ),
             location_columns=[Column(name="testid", type="TEXT", primary=True)],
             data=[
                 GazetteerData(

--- a/poetry.lock
+++ b/poetry.lock
@@ -5554,4 +5554,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "ad1facd36d9915cf3b7564be419770f66945b222852a26e9c8c2b6fd1d5b0256"
+content-hash = "637d89ca221842b7ade16730b18dd45e7d95c2571f07d8284ae5187ec2cdfbdb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ accelerate = "0.34.2"
 pydantic = "^2.7.4"
 geopandas = "^1.0.1"
 flask = "^3.0.3"
+typer = "^0.12.5"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This small PR refactors the cli to use [`typer`](https://typer.tiangolo.com/), the same library as is used by spacy for their cli. This simplifies the cli code while allowing for better extensibility, keeping the interface similar to spacy.

Example for new cli docs:
![grafik](https://github.com/user-attachments/assets/88d567c2-7828-4269-935a-44801af50aa2)
