### PR TITLE
Increase test coverage

### DIFF
--- a/geoparser/__main__.py
+++ b/geoparser/__main__.py
@@ -1,9 +1,9 @@
 from geoparser.cli import app
 
 
-def main():
+def main():  # pragma: no cover
     app()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/geoparser/gazetteers/gazetteer.py
+++ b/geoparser/gazetteers/gazetteer.py
@@ -398,8 +398,6 @@ class LocalDBGazetteer(Gazetteer):
 
                     for tc in toponym_columns:
                         name = tc.name
-                        if name not in chunk.columns:
-                            continue
 
                         df = chunk[[location_identifier, name]].dropna()
 

--- a/geoparser/gazetteers/gazetteer.py
+++ b/geoparser/gazetteers/gazetteer.py
@@ -211,8 +211,6 @@ class LocalDBGazetteer(Gazetteer):
                     try:
                         os.remove(os.path.join(self.data_dir, file_name))
                     except IsADirectoryError:
-                        os.rmdir(os.path.join(self.data_dir, file_name))
-                    except PermissionError:
                         shutil.rmtree(os.path.join(self.data_dir, file_name))
 
     @close

--- a/geoparser/gazetteers/gazetteer.py
+++ b/geoparser/gazetteers/gazetteer.py
@@ -216,7 +216,7 @@ class LocalDBGazetteer(Gazetteer):
                 else:
                     try:
                         os.remove(os.path.join(self.data_dir, file_name))
-                    except IsADirectoryError:
+                    except (IsADirectoryError, PermissionError):
                         shutil.rmtree(os.path.join(self.data_dir, file_name))
 
     @close

--- a/geoparser/gazetteers/geonames.py
+++ b/geoparser/gazetteers/geonames.py
@@ -94,8 +94,6 @@ class GeoNames(LocalDBGazetteer):
             dtype=str,
             skiprows=skiprows,
         )
-        if not chunksize:
-            chunks = [chunks]
 
         return (chunk for chunk in chunks), n_chunks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,13 @@ profile = "black"
 [tool.pytest.ini_options]
 addopts = "--cov=geoparser --cov-report html"
 
+[tool.coverage.report]
+exclude_also = [
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "@(abc\\.)?abstractmethod",
+    ]
+
 [tool.coverage.run]
 omit = ["tests/*"]
 relative_files = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,12 @@ from tests.utils import get_static_test_file
 
 
 @pytest.fixture(scope="session")
+def monkeymodule():
+    with pytest.MonkeyPatch.context() as mp:
+        yield mp
+
+
+@pytest.fixture(scope="session")
 def radio_andorra_id() -> str:
     return "3039328"
 
@@ -39,22 +45,18 @@ def geonames_patched() -> GeoNames:
 
 
 @pytest.fixture(scope="session")
-def geonames_real_data() -> GeoNames:
+def geonames_real_data(monkeymodule) -> GeoNames:
+    # skip download for tests
+    monkeymodule.setattr(GeoNames, "_download_file", lambda *args, **kwargs: None)
+    # do not delete test files
+    monkeymodule.setattr(GeoNames, "clean_dir", lambda *args, **kwargs: None)
     gazetteer = GeoNames()
     tmpdir = py.path.local(tempfile.mkdtemp())
     gazetteer.data_dir = str(
         get_static_test_file(Path("gazetteers") / Path("geonames_1000"))
     )
     gazetteer.db_path = str(tmpdir / Path(gazetteer.db_path).name)
-    for dataset in gazetteer.config.data:
-        gazetteer._load_data(dataset)
-    gazetteer._create_names_table()
-    gazetteer._populate_names_table()
-    gazetteer._create_names_fts_table()
-    gazetteer._populate_names_fts_table()
-    gazetteer._create_locations_table()
-    gazetteer._populate_locations_table()
-    gazetteer._drop_redundant_tables()
+    gazetteer.setup_database()
     return gazetteer
 
 

--- a/tests/static/annotations.json
+++ b/tests/static/annotations.json
@@ -1,0 +1,49 @@
+{
+    "session_id": "a9c6fc34bc854763819b57eb8a8ca67e",
+    "created_at": "2024-11-17T10:17:46.571885",
+    "last_updated": "2024-11-17T10:18:16.366180",
+    "gazetteer": "geonames",
+    "settings": {
+        "one_sense_per_discourse": false,
+        "auto_close_annotation_modal": false
+    },
+    "documents": [
+        {
+            "filename": "text.txt",
+            "spacy_model": "en_core_web_sm",
+            "text": "In Lebanon, two Beirut neighbourhoods woke up this morning to warnings on social media from the Israeli military to evacuate, signalling the resumption of air strikes on the capital for a second day.\nOn Saturday, 12 struck the southern suburbs, and more than 70 strikes hit targets across the rest of Lebanon killing at least thirty people, according to the health ministry there.\nThe Israeli air force says it destroyed weapons storage facilities and missile launching pits in these raids.\nHowever, the many thousands of such raids over the past four weeks have still not ended Hezbollah’s capacity to fire rockets and send drones over the border.\nAround 200 projectiles have been recorded by the Israeli authorities coming from Lebanon over the past 24 hours. Hezbollah has warned that its war with Israel is now entering what it calls a new phase. \n",
+            "toponyms": [
+                {
+                    "text": "Lebanon",
+                    "start": 3,
+                    "end": 10,
+                    "loc_id": "272103"
+                },
+                {
+                    "text": "Beirut",
+                    "start": 16,
+                    "end": 22,
+                    "loc_id": "276781"
+                },
+                {
+                    "text": "Lebanon",
+                    "start": 301,
+                    "end": 308,
+                    "loc_id": ""
+                },
+                {
+                    "text": "Lebanon",
+                    "start": 730,
+                    "end": 737,
+                    "loc_id": ""
+                },
+                {
+                    "text": "Israel",
+                    "start": 801,
+                    "end": 807,
+                    "loc_id": ""
+                }
+            ]
+        }
+    ]
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,8 @@
 import pytest
 from typer.testing import CliRunner
 
+from geoparser.__main__ import app
 from geoparser.annotator import GeoparserAnnotator
-from geoparser.cli import app
 from geoparser.constants import GAZETTEERS_CHOICES
 from geoparser.gazetteers.gazetteer import LocalDBGazetteer
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,37 @@
+import pytest
+from typer.testing import CliRunner
+
+from geoparser.annotator import GeoparserAnnotator
+from geoparser.cli import app
+from geoparser.constants import GAZETTEERS_CHOICES
+from geoparser.gazetteers.gazetteer import LocalDBGazetteer
+
+runner = CliRunner()
+
+
+@pytest.mark.parametrize("gazetteer", ["geonames", "swissnames3d", "nonexisting"])
+def test_download(gazetteer: str, monkeypatch):
+    valid_gazetteers = [e.value for e in GAZETTEERS_CHOICES]
+    monkeypatch.setattr(
+        LocalDBGazetteer, "setup_database", lambda *args, **kwargs: None
+    )
+    result = runner.invoke(app, ["download", gazetteer])
+    # cli will return OK code with supported gazetteer
+    if gazetteer in valid_gazetteers:
+        assert result.exit_code == 0
+    # unsupported gazetteer leads to error
+    else:
+        assert result.exit_code == 2
+
+
+def test_annotator(monkeypatch):
+    monkeypatch.setattr(GeoparserAnnotator, "run", lambda *args, **kwargs: None)
+    result = runner.invoke(app, ["annotator"])
+    # cli will always return OK code
+    assert result.exit_code == 0
+
+
+def test_unsupported_command():
+    result = runner.invoke(app, ["unsupported_command"])
+    # unsupported command leads to error
+    assert result.exit_code == 2

--- a/tests/test_gazetteer.py
+++ b/tests/test_gazetteer.py
@@ -238,7 +238,6 @@ def test_drop_redundant_tables(geonames_patched: GeoNames):
     redundant_tables = [dataset.name for dataset in geonames_patched.config.data]
     tables_query = "SELECT name FROM sqlite_master"
     geonames_patched._initiate_connection()
-    cursor = geonames_patched._get_cursor()
     geonames_patched._commit()
     # 2. removing redundant tables
     geonames_patched._drop_redundant_tables()

--- a/tests/test_gazetteer.py
+++ b/tests/test_gazetteer.py
@@ -225,6 +225,46 @@ def test_create_locations_table(geonames_patched: GeoNames):
     check_table_creation(geonames_patched, "locations", "_create_locations_table")
 
 
+def test_create_values_table(geonames_patched: GeoNames):
+    attribute = "admin1_name"
+    table_name = f"{attribute}_values"
+    # 1. table does not exist before creation
+    tables_query = "SELECT name FROM sqlite_master"
+    tables_before = execute_query(geonames_patched, tables_query)
+    assert tables_before == [] or table_name not in tables_before[0]
+    # 2. create table with specified method
+    geonames_patched._create_values_table(attribute)
+    # 3. table exists after creation
+    tables_after = execute_query(geonames_patched, tables_query)
+    assert len(tables_after) > len(tables_before) and table_name in tables_after[0]
+
+
+def test_populate_values_table(geonames_patched: GeoNames):
+    attribute = "admin1_name"
+    table_name = f"{attribute}_values"
+    expected_first_row = ("Canillo",)
+    # 1. setup
+    for dataset in geonames_patched.config.data:
+        geonames_patched._load_data(dataset)
+    geonames_patched._create_names_table()
+    geonames_patched._populate_names_table()
+    geonames_patched._create_names_fts_table()
+    geonames_patched._populate_names_fts_table()
+    geonames_patched._create_locations_table()
+    geonames_patched._populate_locations_table()
+    geonames_patched._create_values_table(attribute)
+    # 2. table is empty before populating it
+    rows_query = f"SELECT * FROM {table_name}"
+    rows_before = execute_query(geonames_patched, rows_query)
+    assert rows_before == []
+    # 3. populating the table with specified method
+    geonames_patched._populate_values_table(attribute)
+    # 4. table contains a specific first row
+    rows_after = execute_query(geonames_patched, rows_query)
+    assert len(rows_after) > 0
+    assert rows_after[0] == expected_first_row
+
+
 def test_drop_redundant_tables(geonames_patched: GeoNames):
     # setup: create tables from previous steps
     for dataset in geonames_patched.config.data:

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -162,12 +162,12 @@ def test_annotate(
     corpus_bad_annotations: list[dict],
     include_unmatched: bool,
 ):
-    annotated_corpus = trainer_real_data.annotate(
-        corpus_good_annotations, include_unmatched=include_unmatched
-    )
-    assert type(annotated_corpus) is list
     for corpus in [corpus_good_annotations, corpus_bad_annotations]:
-        for doc, raw_doc in zip(annotated_corpus, corpus_good_annotations):
+        annotated_corpus = trainer_real_data.annotate(
+            corpus, include_unmatched=include_unmatched
+        )
+        assert type(annotated_corpus) is list
+        for doc, raw_doc in zip(annotated_corpus, corpus):
             assert type(doc) is GeoDoc
             # entities are sorted by occurrence in text
             assert list(doc.ents) == sorted(doc.ents, key=lambda x: x.start)


### PR DESCRIPTION
This PR adds some new tests and minor modifications to bring the test coverage of the non-annotator part of `geoparser` to 100%.

**Changes:**
- Add tests for cli
- Complete tests for trainer and gazetteer
- Remove unused `if` statements and simplify exception handling