### PR TITLE
add paths filter to licenses workflow

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - development
+    paths:
+      - 'pyproject.toml'
+      - 'poetry.lock'
 
 permissions:
   contents: write


### PR DESCRIPTION
This PR adds paths filter to the licenses workflow so that `pyproject.toml` and `poetry.lock` can be checked for changes before the `THIRD_PARTY_LICENSES` file update is executed.