### PR TITLE
Feature/geodoc locations

### DIFF
--- a/geoparser/geodoc/geodoc.py
+++ b/geoparser/geodoc/geodoc.py
@@ -7,46 +7,6 @@ GeoSpan.set_extension("loc_score", default=None)
 GeoSpan.set_extension("candidate_cache", default={})
 
 
-class Locations:
-    """Class representing a collection of location data with convenient access methods."""
-
-    def __init__(self, data: list[dict]):
-        """
-        Initialize Locations with a list of location data dictionaries.
-
-        Args:
-            data (list[dict]): List of dictionaries containing location information.
-        """
-        self.data = data
-
-    def __getitem__(self, key):
-        """
-        Get item(s) from location data based on key(s).
-
-        Args:
-            key (str or tuple): The key or tuple of keys to retrieve from each location dict.
-
-        Returns:
-            list: List of values or tuples of values corresponding to the key(s).
-        """
-        if isinstance(key, tuple):
-            return [
-                (tuple(item.get(k, None) for k in key) if item else (None,) * len(key))
-                for item in self.data
-            ]
-        else:
-            return [item.get(key, None) if item else None for item in self.data]
-
-    def __repr__(self):
-        """
-        Return the string representation of the location data.
-
-        Returns:
-            str: String representation of the location data.
-        """
-        return repr(self.data)
-
-
 class GeoDoc(Doc):
     """Custom spaCy Doc class extended for geoparsing."""
 
@@ -73,12 +33,10 @@ class GeoDoc(Doc):
         Get location information for all toponyms in the document.
 
         Returns:
-            Locations: A Locations object containing location data for toponyms.
+            list[dict]: A list of dictionaries containing location data for toponyms.
         """
-        return Locations(
-            self.geoparser.gazetteer.query_location_info(
-                [toponym._.loc_id for toponym in self.toponyms]
-            )
+        return self.geoparser.gazetteer.query_location_info(
+            [toponym._.loc_id for toponym in self.toponyms]
         )
 
     @property

--- a/tests/test_geodoc.py
+++ b/tests/test_geodoc.py
@@ -1,60 +1,20 @@
-import typing as t
-
 import pytest
 
 from geoparser.geodoc import GeoDoc
-from geoparser.geodoc.geodoc import Locations
 from geoparser.geospan import GeoSpan
-
-
-@pytest.fixture(scope="session")
-def locations(geonames_real_data, radio_andorra_id) -> Locations:
-    locations = Locations(geonames_real_data.query_location_info([radio_andorra_id]))
-    return locations
-
-
-def test_locations_repr(locations: Locations):
-    assert (
-        locations.__repr__() == "[{'geonameid': '3039328', "
-        "'name': 'Radio Andorra', "
-        "'feature_type': 'radio station', "
-        "'latitude': 42.5282, "
-        "'longitude': 1.57089, "
-        "'elevation': None, "
-        "'population': 0, "
-        "'admin2_geonameid': None, "
-        "'admin2_name': None, "
-        "'admin1_geonameid': '3040684', "
-        "'admin1_name': 'Encamp', "
-        "'country_geonameid': '3041565', "
-        "'country_name': 'Andorra'}]"
-    )
-
-
-@pytest.mark.parametrize(
-    "key,expected",
-    [
-        ("name", ["Radio Andorra"]),
-        (("name", "admin1_name"), [("Radio Andorra", "Encamp")]),
-        ("non_existing", [None]),
-    ],
-)
-def test_locations_access(
-    locations: Locations, key: t.Optional[str], expected: t.Union[str, int, float, None]
-):
-    assert locations[key] == expected
 
 
 def test_geodoc_locations(geodocs: list[GeoDoc]):
     for elem in geodocs:
         locations = elem.locations
-        assert type(locations) is Locations
-        assert len(locations["name"]) == 1
+        assert isinstance(locations, list)
+        assert all(isinstance(loc, (dict, type(None))) for loc in locations)
+        assert len(locations) == 1
 
 
 def test_geodoc_toponyms(geodocs: list[GeoDoc]):
     for elem in geodocs:
         toponyms = elem.toponyms
-        assert type(toponyms) is tuple
-        assert type(toponyms[0]) is GeoSpan
+        assert isinstance(toponyms, tuple)
+        assert all(isinstance(toponym, GeoSpan) for toponym in toponyms)
         assert len(toponyms) == 1


### PR DESCRIPTION
This PR removes the `Locations` class to switch back to a more intuitive way of retrieving location information from parsed documents. This means that `GeoDoc.locations` now returns a list of location dictionaries instead of a `Locations` objects.