### PR TITLE
Add integration tests for gazetteer download

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,35 @@
+name: run
+
+on:
+  push:
+    branches:
+      - '**'
+
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        gazetteer: [geonames, swissnames3d]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v5
+      - name: Install poetry
+        uses: abatilo/actions-poetry@v3
+      - name: Setup local virtual environment
+        run: |
+          poetry config virtualenvs.create true --local
+          poetry config virtualenvs.in-project true --local
+      - uses: actions/cache@v4
+        name: Define cache for the virtual environment based on poetry.lock file
+        with:
+          path: ./.venv
+          key: venv-${{ hashFiles('poetry.lock') }}
+      - name: Install project dependencies
+        run: poetry install
+      - name: Download gazetteer
+        run: poetry run python -m geoparser download ${{ matrix.gazetteer }}
+      - name: Run E2E-script
+        run: poetry run python ./tests/integration/e2e.py

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,9 @@ name: integration-tests
 on:
   push:
     branches:
-      - '**'
+      - development
+      - staging
+      - main
 
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: run
+name: integration-tests
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 
 jobs:
-  integration-tests:
+  gazetteer:
     strategy:
       matrix:
         gazetteer: [geonames, swissnames3d]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,7 +7,7 @@ on:
 
 
 jobs:
-  test:
+  integration-tests:
     strategy:
       matrix:
         gazetteer: [geonames, swissnames3d]
@@ -32,4 +32,4 @@ jobs:
       - name: Download gazetteer
         run: poetry run python -m geoparser download ${{ matrix.gazetteer }}
       - name: Run E2E-script
-        run: poetry run python ./tests/integration/e2e.py
+        run: poetry run python ./tests/integration/e2e.py ${{ matrix.gazetteer }}

--- a/tests/integration/e2e.py
+++ b/tests/integration/e2e.py
@@ -1,7 +1,6 @@
-from geoparser import Geoparser
-from geoparser import GeoparserTrainer
-
 import typer
+
+from geoparser import Geoparser, GeoparserTrainer
 
 
 def run_gazetteer(gazetteer: str):

--- a/tests/integration/e2e.py
+++ b/tests/integration/e2e.py
@@ -13,63 +13,19 @@ def run_gazetteer(gazetteer: str):
     texts = [
         "Zurich is a city rich in history.",
         "Geneva is known for its role in international diplomacy.",
-        "Munich is famous for its annual Oktoberfest celebration.",
     ]
     docs = geo.parse(texts)
     for doc in docs:
-        identifiers = [
-            (l["name"], l["admin1_name"], l["country_name"]) for l in doc.locations
-        ]
+        name = "name" if gazetteer == "geonames" else "NAME"
+        identifier1 = "admin1_name" if gazetteer == "geonames" else "BEZIRK_NAME"
+        identifier2 = "country_name" if gazetteer == "geonames" else "KANTON_NAME"
+        identifiers = [(l[name], l[identifier1], l[identifier2]) for l in doc.locations]
         for toponym, identifier in zip(doc.toponyms, identifiers):
             print(toponym, "->", identifier)
 
 
-def run_trainer(gazetteer: str):
-    print("----------\nrun_trainer\n----------")
-    train_corpus = [
-        {
-            "text": "Zurich is a city in Switzerland.",
-            "toponyms": [
-                {"text": "Zurich", "start": 0, "end": 6, "loc_id": "2657896"},
-                {"text": "Switzerland", "start": 20, "end": 31, "loc_id": "2658434"},
-            ],
-        },
-        {
-            "text": "Geneva is known for international diplomacy.",
-            "toponyms": [{"text": "Geneva", "start": 0, "end": 6, "loc_id": "2660646"}],
-        },
-        {
-            "text": "Munich hosts the annual Oktoberfest.",
-            "toponyms": [{"text": "Munich", "start": 0, "end": 6, "loc_id": "2867714"}],
-        },
-    ]
-    trainer = GeoparserTrainer(
-        spacy_model="en_core_web_sm",
-        transformer_model="bert-base-uncased",
-        gazetteer=gazetteer,
-    )
-    train_docs = trainer.annotate(train_corpus)
-    output_path = "path_to_custom_model"
-    trainer.train(train_docs, output_path=output_path)
-    test_docs = trainer.annotate(train_corpus)
-    trainer.resolve(test_docs)
-    evaluation_results = trainer.evaluate(test_docs)
-    print(evaluation_results)
-
-
-def use_model(gazetteer: str):
-    print("----------\nuse_model\n----------")
-    geo = Geoparser(
-        spacy_model="en_core_web_sm", transformer_model="path_to_custom_model"
-    )
-    docs = geo.parse(["New text to parse"])
-    print(docs)
-
-
 def main(gazetteer: str):
     run_gazetteer(gazetteer)
-    run_trainer(gazetteer)
-    use_model(gazetteer)
 
 
 if __name__ == "__main__":

--- a/tests/integration/e2e.py
+++ b/tests/integration/e2e.py
@@ -1,6 +1,6 @@
 import typer
 
-from geoparser import Geoparser, GeoparserTrainer
+from geoparser import Geoparser
 
 
 def run_gazetteer(gazetteer: str):

--- a/tests/integration/e2e.py
+++ b/tests/integration/e2e.py
@@ -1,81 +1,77 @@
-#########################################################
-# GeoNames
-#########################################################
-
-
 from geoparser import Geoparser
-
-geo = Geoparser(
-    spacy_model="en_core_web_sm",
-    transformer_model="dguzh/geo-all-MiniLM-L6-v2",
-    gazetteer="geonames",
-)
-
-texts = [
-    "Zurich is a city rich in history.",
-    "Geneva is known for its role in international diplomacy.",
-    "Munich is famous for its annual Oktoberfest celebration.",
-]
-
-docs = geo.parse(texts)
-
-for doc in docs:
-    identifiers = [(l["name"], l["admin1_name"], l["country_name"]) for l in doc.locations]
-    for toponym, identifier in zip(doc.toponyms, identifiers):
-        print(toponym, "->", identifier)
-
-#########################################################
-# Trainer
-#########################################################
-
 from geoparser import GeoparserTrainer
 
-train_corpus = [
-    {
-        "text": "Zurich is a city in Switzerland.",
-        "toponyms": [
-            {"text": "Zurich", "start": 0, "end": 6, "loc_id": "2657896"},
-            {"text": "Switzerland", "start": 20, "end": 31, "loc_id": "2658434"}
+import typer
+
+
+def run_gazetteer(gazetteer: str):
+    print("----------\nrun_gazetteer\n----------")
+    geo = Geoparser(
+        spacy_model="en_core_web_sm",
+        transformer_model="dguzh/geo-all-MiniLM-L6-v2",
+        gazetteer=gazetteer,
+    )
+    texts = [
+        "Zurich is a city rich in history.",
+        "Geneva is known for its role in international diplomacy.",
+        "Munich is famous for its annual Oktoberfest celebration.",
+    ]
+    docs = geo.parse(texts)
+    for doc in docs:
+        identifiers = [
+            (l["name"], l["admin1_name"], l["country_name"]) for l in doc.locations
         ]
-    },
-    {
-        "text": "Geneva is known for international diplomacy.",
-        "toponyms": [
-            {"text": "Geneva", "start": 0, "end": 6, "loc_id": "2660646"}
-        ]
-    },
-    {
-        "text": "Munich hosts the annual Oktoberfest.",
-        "toponyms": [
-            {"text": "Munich", "start": 0, "end": 6, "loc_id": "2867714"}
-        ]
-    }
-]
+        for toponym, identifier in zip(doc.toponyms, identifiers):
+            print(toponym, "->", identifier)
 
-trainer = GeoparserTrainer(
-    spacy_model="en_core_web_sm", transformer_model="bert-base-uncased"
-)
 
-train_docs = trainer.annotate(train_corpus)
+def run_trainer(gazetteer: str):
+    print("----------\run_trainer\n----------")
+    train_corpus = [
+        {
+            "text": "Zurich is a city in Switzerland.",
+            "toponyms": [
+                {"text": "Zurich", "start": 0, "end": 6, "loc_id": "2657896"},
+                {"text": "Switzerland", "start": 20, "end": 31, "loc_id": "2658434"},
+            ],
+        },
+        {
+            "text": "Geneva is known for international diplomacy.",
+            "toponyms": [{"text": "Geneva", "start": 0, "end": 6, "loc_id": "2660646"}],
+        },
+        {
+            "text": "Munich hosts the annual Oktoberfest.",
+            "toponyms": [{"text": "Munich", "start": 0, "end": 6, "loc_id": "2867714"}],
+        },
+    ]
+    trainer = GeoparserTrainer(
+        spacy_model="en_core_web_sm",
+        transformer_model="bert-base-uncased",
+        gazetteer=gazetteer,
+    )
+    train_docs = trainer.annotate(train_corpus)
+    output_path = "path_to_custom_model"
+    trainer.train(train_docs, output_path=output_path)
+    test_docs = trainer.annotate(train_corpus)
+    trainer.resolve(test_docs)
+    evaluation_results = trainer.evaluate(test_docs)
+    print(evaluation_results)
 
-output_path = "path_to_custom_model"
 
-trainer.train(train_docs, output_path=output_path)
+def use_model(gazetteer: str):
+    print("----------\use_model\n----------")
+    geo = Geoparser(
+        spacy_model="en_core_web_sm", transformer_model="path_to_custom_model"
+    )
+    docs = geo.parse(["New text to parse"])
+    print(docs)
 
-test_docs = trainer.annotate(train_corpus)
 
-trainer.resolve(test_docs)
+def main(gazetteer: str):
+    run_gazetteer(gazetteer)
+    run_trainer(gazetteer)
+    use_model(gazetteer)
 
-evaluation_results = trainer.evaluate(test_docs)
 
-print(evaluation_results)
-
-#########################################################
-# Use model
-#########################################################
-
-from geoparser import Geoparser
-
-geo = Geoparser(spacy_model="en_core_web_sm", transformer_model="path_to_custom_model")
-
-docs = geo.parse(["New text to parse"])
+if __name__ == "__main__":
+    typer.run(main)

--- a/tests/integration/e2e.py
+++ b/tests/integration/e2e.py
@@ -25,7 +25,7 @@ def run_gazetteer(gazetteer: str):
 
 
 def run_trainer(gazetteer: str):
-    print("----------\run_trainer\n----------")
+    print("----------\nrun_trainer\n----------")
     train_corpus = [
         {
             "text": "Zurich is a city in Switzerland.",
@@ -58,7 +58,7 @@ def run_trainer(gazetteer: str):
 
 
 def use_model(gazetteer: str):
-    print("----------\use_model\n----------")
+    print("----------\nuse_model\n----------")
     geo = Geoparser(
         spacy_model="en_core_web_sm", transformer_model="path_to_custom_model"
     )

--- a/tests/integration/e2e.py
+++ b/tests/integration/e2e.py
@@ -1,0 +1,81 @@
+#########################################################
+# GeoNames
+#########################################################
+
+
+from geoparser import Geoparser
+
+geo = Geoparser(
+    spacy_model="en_core_web_sm",
+    transformer_model="dguzh/geo-all-MiniLM-L6-v2",
+    gazetteer="geonames",
+)
+
+texts = [
+    "Zurich is a city rich in history.",
+    "Geneva is known for its role in international diplomacy.",
+    "Munich is famous for its annual Oktoberfest celebration.",
+]
+
+docs = geo.parse(texts)
+
+for doc in docs:
+    identifiers = [(l["name"], l["admin1_name"], l["country_name"]) for l in doc.locations]
+    for toponym, identifier in zip(doc.toponyms, identifiers):
+        print(toponym, "->", identifier)
+
+#########################################################
+# Trainer
+#########################################################
+
+from geoparser import GeoparserTrainer
+
+train_corpus = [
+    {
+        "text": "Zurich is a city in Switzerland.",
+        "toponyms": [
+            {"text": "Zurich", "start": 0, "end": 6, "loc_id": "2657896"},
+            {"text": "Switzerland", "start": 20, "end": 31, "loc_id": "2658434"}
+        ]
+    },
+    {
+        "text": "Geneva is known for international diplomacy.",
+        "toponyms": [
+            {"text": "Geneva", "start": 0, "end": 6, "loc_id": "2660646"}
+        ]
+    },
+    {
+        "text": "Munich hosts the annual Oktoberfest.",
+        "toponyms": [
+            {"text": "Munich", "start": 0, "end": 6, "loc_id": "2867714"}
+        ]
+    }
+]
+
+trainer = GeoparserTrainer(
+    spacy_model="en_core_web_sm", transformer_model="bert-base-uncased"
+)
+
+train_docs = trainer.annotate(train_corpus)
+
+output_path = "path_to_custom_model"
+
+trainer.train(train_docs, output_path=output_path)
+
+test_docs = trainer.annotate(train_corpus)
+
+trainer.resolve(test_docs)
+
+evaluation_results = trainer.evaluate(test_docs)
+
+print(evaluation_results)
+
+#########################################################
+# Use model
+#########################################################
+
+from geoparser import Geoparser
+
+geo = Geoparser(spacy_model="en_core_web_sm", transformer_model="path_to_custom_model")
+
+docs = geo.parse(["New text to parse"])


### PR DESCRIPTION
This small PR adds a workflow for integration tests (gazetteer download). It tests the database setup of the available gazetteers with real data, as well as running a small test script to verify that the database can be used.

It should be enough to sporadically run this wokflow to verify that the source data for the gazetteers has not changed in a meaningful way. We could run it on `development`, `staging`, and `main`.