### PR TITLE
Run tests on compatible Python versions on Windows and Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,20 +7,24 @@ on:
     tags:
       - '**'
   pull_request:
-permissions:
-  pull-requests: write
 
 
 jobs:
   test:
     name: test
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install poetry
-        uses: abatilo/actions-poetry@v3
+        run: pipx install poetry --python python${{ matrix.python-version }}
       - name: Setup local virtual environment
         run: |
           poetry config virtualenvs.create true --local
@@ -29,12 +33,36 @@ jobs:
         name: Define cache for the virtual environment based on poetry.lock file
         with:
           path: ./.venv
-          key: venv-${{ hashFiles('poetry.lock') }}
+          key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install project dependencies
         run: poetry install
       - name: Run pytest
         run: poetry run pytest -v --cov=geoparser
+      - run: mkdir coverage
+      - run: mv .coverage coverage/.coverage.${{ runner.os }}-py${{ matrix.python-version }}
+      - name: Store coverage files
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}-${{ matrix.python-version }}
+          path: coverage
+          include-hidden-files: true
+
+  coverage-combine:
+    needs: [test]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v5
+      - name: Get coverage files
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          pattern: coverage-*
+          path: coverage
       - run: pip install coverage[toml]
+      - run: coverage combine coverage
+      - run: coverage report
       - run: coverage html --show-contexts --title "geoparser coverage for ${{ github.sha }}"
       - name: Coverage comment
         id: coverage_comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,9 +65,9 @@ jobs:
       - run: coverage report
       - run: coverage html --show-contexts --title "geoparser coverage for ${{ github.sha }}"
       - name: Coverage comment
-        if: github.event_name == 'pull_request'
         id: coverage_comment
         uses: py-cov-action/python-coverage-comment-action@v3
+        if: github.event_name == 'pull_request'
         with:
           GITHUB_TOKEN: ${{ github.token }}
           MINIMUM_GREEN: 100

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
 
   coverage-combine:
     needs: [test]
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Python
@@ -65,13 +65,13 @@ jobs:
       - run: coverage report
       - run: coverage html --show-contexts --title "geoparser coverage for ${{ github.sha }}"
       - name: Coverage comment
+        if: github.event_name == 'pull_request'
         id: coverage_comment
         uses: py-cov-action/python-coverage-comment-action@v3
-        if: github.event_name == 'pull_request'
         with:
           GITHUB_TOKEN: ${{ github.token }}
           MINIMUM_GREEN: 100
-          MINIMUM_ORANGE: 90
+          MINIMUM_ORANGE: 95
       - name: Store Pull Request comment to be posted
         uses: actions/upload-artifact@v4
         if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,5 +62,13 @@ exclude_also = [
     ]
 
 [tool.coverage.run]
+source = ["geoparser"]
 omit = ["tests/*"]
 relative_files = true
+
+[tool.coverage.paths]
+source = [
+    'pydantic/',
+    '/Users/runner/work/dguzh/geoparser/geoparser/',
+    'D:\a\dguzh\geoparser\geoparser',
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,6 @@ relative_files = true
 
 [tool.coverage.paths]
 source = [
-    '*/geoparser/geoparser',
-    '*\geoparser\geoparser',
+    'geoparser/',
+    'geoparser\',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ relative_files = true
 
 [tool.coverage.paths]
 source = [
-    'pydantic/',
-    '/Users/runner/work/dguzh/geoparser/geoparser/',
-    'D:\a\dguzh\geoparser\geoparser',
+    '*/geoparser/geoparser',
+    '*\geoparser\geoparser',
 ]


### PR DESCRIPTION
This PR adjusts the test workflow to run tests on all compatible Python versions on Windows and Ubuntu.

**Limitation:**
No tests for macos have been included yet because compatibility issues with GitHub runners have to be resolved first.