### PR TITLE
Fix disk space problems with integration tests workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,13 +1,7 @@
 name: integration-tests
 
 on:
-  workflow_run:
-    workflows: test
-    branches:
-      - development
-      - staging
-      - main
-    types: completed
+  push:
 
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,11 +38,6 @@ jobs:
         run: |
           poetry config virtualenvs.create true --local
           poetry config virtualenvs.in-project true --local
-      - uses: actions/cache@v4
-        name: Define cache for the virtual environment based on poetry.lock file
-        with:
-          path: ./.venv
-          key: venv-ubuntu-latest-3.10-${{ hashFiles('poetry.lock') }}
       - name: Install project dependencies
         run: poetry install
       - name: Download gazetteer

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,11 +1,13 @@
 name: integration-tests
 
 on:
-  push:
+  workflow_run:
+    workflows: test
     branches:
       - development
       - staging
       - main
+    types: completed
 
 
 jobs:
@@ -28,7 +30,7 @@ jobs:
         name: Define cache for the virtual environment based on poetry.lock file
         with:
           path: ./.venv
-          key: venv-${{ hashFiles('poetry.lock') }}
+          key: venv-ubuntu-latest-3.10-${{ hashFiles('poetry.lock') }}
       - name: Install project dependencies
         run: poetry install
       - name: Download gazetteer

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,6 +11,18 @@ jobs:
         gazetteer: [geonames, swissnames3d]
     runs-on: ubuntu-latest
     steps:
+      - name: Remove unused software
+        run: |
+          echo "Available storage before:"
+          sudo df -h
+          echo
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          echo "Available storage after:"
+          sudo df -h
+          echo
       - uses: actions/checkout@v4
       - name: Install Python
         uses: actions/setup-python@v5

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,7 +1,13 @@
 name: integration-tests
 
 on:
-  push:
+  workflow_run:
+    workflows: test
+    branches:
+      - development
+      - staging
+      - main
+    types: completed
 
 
 jobs:

--- a/geoparser/gazetteers/gazetteer.py
+++ b/geoparser/gazetteers/gazetteer.py
@@ -182,6 +182,7 @@ class LocalDBGazetteer(Gazetteer):
         for dataset in self.config.data:
             self._download_file(dataset)
             self._load_data(dataset)
+            self._delete_file(dataset)
 
         self._create_names_table()
         self._populate_names_table()
@@ -281,6 +282,22 @@ class LocalDBGazetteer(Gazetteer):
         """
         self._create_data_table(dataset)
         self._populate_data_table(dataset)
+
+    def _delete_file(self, dataset: GazetteerData) -> None:
+        """
+        Delete a previously downloaded file for a dataset.
+
+        Args:
+            dataset (GazetteerData): Dataset configuration object.
+        """
+        url = dataset.url
+        filename = url.split("/")[-1]
+        file_path = os.path.join(self.data_dir, filename)
+        if not os.path.exists(file_path):
+            try:
+                os.remove(file_path)
+            except (IsADirectoryError, PermissionError):
+                shutil.rmtree(file_path)
 
     @abstractmethod
     def _read_file(

--- a/geoparser/gazetteers/gazetteer.py
+++ b/geoparser/gazetteers/gazetteer.py
@@ -296,7 +296,7 @@ class LocalDBGazetteer(Gazetteer):
         if os.path.exists(file_path):
             try:
                 os.remove(file_path)
-            except PermissionError:
+            except (IsADirectoryError, PermissionError):
                 shutil.rmtree(file_path)
 
     @abstractmethod

--- a/geoparser/gazetteers/gazetteer.py
+++ b/geoparser/gazetteers/gazetteer.py
@@ -293,7 +293,7 @@ class LocalDBGazetteer(Gazetteer):
         url = dataset.url
         filename = url.split("/")[-1]
         file_path = os.path.join(self.data_dir, filename)
-        if not os.path.exists(file_path):
+        if os.path.exists(file_path):
             try:
                 os.remove(file_path)
             except (IsADirectoryError, PermissionError):

--- a/geoparser/gazetteers/gazetteer.py
+++ b/geoparser/gazetteers/gazetteer.py
@@ -296,7 +296,7 @@ class LocalDBGazetteer(Gazetteer):
         if os.path.exists(file_path):
             try:
                 os.remove(file_path)
-            except (IsADirectoryError, PermissionError):
+            except PermissionError:
                 shutil.rmtree(file_path)
 
     @abstractmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,8 @@ def geonames_patched() -> GeoNames:
 def geonames_real_data(monkeymodule) -> GeoNames:
     # skip download for tests
     monkeymodule.setattr(GeoNames, "_download_file", lambda *args, **kwargs: None)
+    # skip deleting downloaded files
+    monkeymodule.setattr(GeoNames, "_delete_file", lambda *args, **kwargs: None)
     # do not delete test files
     monkeymodule.setattr(GeoNames, "clean_dir", lambda *args, **kwargs: None)
     gazetteer = GeoNames()

--- a/tests/test_gazetteer.py
+++ b/tests/test_gazetteer.py
@@ -1,7 +1,6 @@
 import sqlite3
 import tempfile
 import typing as t
-from difflib import get_close_matches
 from pathlib import Path
 
 import py
@@ -133,6 +132,25 @@ def test_download_file(
     # a.txt downloaded as is, b.zip has been extracted and is still around
     zipfile = [raw_file] if raw_file.endswith(".zip") else []
     assert sorted(files) == sorted(dataset.extracted_files + zipfile)
+
+
+def test_delete_file(localdb_gazetteer: LocalDBGazetteer):
+    dataset = GazetteerData(
+        name="a",
+        url="https://my.url.org/path/to/a.txt",
+        extracted_files=["a.txt"],
+        columns=[Column(name="", type="")],
+    )
+    raw_file = Path(localdb_gazetteer.data_dir) / dataset.url.split("/")[-1]
+    # create file to delete
+    with open(get_static_test_file(raw_file), "w") as _:
+        pass
+    # file exists before deletion
+    assert raw_file.is_file()
+    # delete file
+    localdb_gazetteer._delete_file(dataset)
+    # file has been deleted
+    assert not raw_file.is_file()
 
 
 def test_create_data_table(geonames_patched: GeoNames):

--- a/tests/test_gazetteer.py
+++ b/tests/test_gazetteer.py
@@ -133,24 +133,30 @@ def test_download_file(
     zipfile = [raw_file] if raw_file.endswith(".zip") else []
     assert sorted(files) == sorted(dataset.extracted_files + zipfile)
 
-
-def test_delete_file(localdb_gazetteer: LocalDBGazetteer):
+@pytest.mark.parametrize("is_directory", [True, False])
+def test_delete_file(localdb_gazetteer: LocalDBGazetteer, is_directory: bool):
     dataset = GazetteerData(
         name="a",
         url="https://my.url.org/path/to/a.txt",
         extracted_files=["a.txt"],
         columns=[Column(name="", type="")],
     )
-    raw_file = Path(localdb_gazetteer.data_dir) / dataset.url.split("/")[-1]
-    # create file to delete
-    with open(get_static_test_file(raw_file), "w") as _:
-        pass
-    # file exists before deletion
-    assert raw_file.is_file()
-    # delete file
+    raw_element = Path(localdb_gazetteer.data_dir) / dataset.url.split("/")[-1]
+    if is_directory:
+        # create directory to delete
+        raw_element.mkdir(parents=True, exist_ok=True)
+        test_function = lambda x: x.is_dir()
+    else:
+        # create file to delete
+        with open(get_static_test_file(raw_element), "w") as _:
+            pass
+        test_function = lambda x: x.is_file()
+    # element exists before deletion
+    assert test_function(raw_element)
+    # delete element
     localdb_gazetteer._delete_file(dataset)
-    # file has been deleted
-    assert not raw_file.is_file()
+    # element has been deleted
+    assert not test_function(raw_element)
 
 
 def test_create_data_table(geonames_patched: GeoNames):

--- a/tests/test_gazetteer.py
+++ b/tests/test_gazetteer.py
@@ -133,6 +133,7 @@ def test_download_file(
     zipfile = [raw_file] if raw_file.endswith(".zip") else []
     assert sorted(files) == sorted(dataset.extracted_files + zipfile)
 
+
 @pytest.mark.parametrize("is_directory", [True, False])
 def test_delete_file(localdb_gazetteer: LocalDBGazetteer, is_directory: bool):
     dataset = GazetteerData(


### PR DESCRIPTION
This small PR attempts to fix the disk space problems of the integration tests workflow, which currently fails unpredictably in some cases with `OperationalError: database or disk is full`.

It implements three measures:
- Individually delete the downloaded files once they have been loaded and before the next file is downloaded
- ~Always wait for tests to complete and reuse the cached ubuntu-3.10 `venv` (do not `poetry install` from scratch)~
- At the start of the job, delete unused software to free up around `14G`