### PR TITLE
Fix Windows newlines

### DIFF
--- a/geoparser/annotator/db/models/document.py
+++ b/geoparser/annotator/db/models/document.py
@@ -1,8 +1,11 @@
 import typing as t
 import uuid
 
+from pydantic import AfterValidator
 from sqlalchemy import UUID, Column, ForeignKey
 from sqlmodel import Field, Relationship, SQLModel
+
+from geoparser.annotator.db.models.validators import normalize_newlines
 
 if t.TYPE_CHECKING:
     from geoparser.annotator.db.models.session import Session
@@ -13,7 +16,7 @@ class DocumentBase(SQLModel):
     filename: str
     spacy_model: str
     spacy_applied: t.Optional[bool] = False
-    text: str
+    text: t.Annotated[str, AfterValidator(normalize_newlines)]
 
 
 class Document(DocumentBase, table=True):

--- a/geoparser/annotator/db/models/validators.py
+++ b/geoparser/annotator/db/models/validators.py
@@ -1,0 +1,2 @@
+def normalize_newlines(to_normalize: str) -> str:
+    return to_normalize.replace("\r\n", "\n").replace("\r", "\n")

--- a/tests/test_annotator_validators.py
+++ b/tests/test_annotator_validators.py
@@ -1,0 +1,16 @@
+import pytest
+
+from geoparser.annotator.db.models.validators import normalize_newlines
+
+
+@pytest.mark.parametrize(
+    "test_str,expected",
+    [
+        ("1\n2\n3\n4", "1\n2\n3\n4"),  # leave as is
+        ("1\r2\r3\r4", "1\n2\n3\n4"),  # normalize carriage return
+        ("1\r\n2\r\n3\r\n4", "1\n2\n3\n4"),  # normalize Windows newlines
+        ("1\n2\r3\n4", "1\n2\n3\n4"),  # handle mixed cases
+    ],
+)
+def test_normalize_newlines(test_str: str, expected: str):
+    assert normalize_newlines(test_str) == expected


### PR DESCRIPTION
This small PR fixes the phenomenon, that toponym positions of manually created toponyms can be off on Windows with text files containing newlines. It adds a validator to the `Document.text` attribute normalizing newlines to `\n` at initialization/creation.