### PR TITLE
Fix annotator startup with user dir not existing

### DIFF
--- a/geoparser/annotator/db/db.py
+++ b/geoparser/annotator/db/db.py
@@ -6,6 +6,7 @@ from sqlalchemy import event
 from sqlmodel import Session, SQLModel, create_engine
 
 db_location = Path(user_data_dir("geoparser", "")) / "annotator" / "annotator.db"
+db_location.parent.mkdir(parents=True, exist_ok=True)
 sqlite_url = f"sqlite:///{db_location}"
 
 engine = create_engine(sqlite_url, echo=False)


### PR DESCRIPTION
This small PR fixes the annotator startup for cases, where the `annotator` user dir is not existing yet. It simply adds a line creating the directory if needed.
This will resolve problems with annotator usage with "fresh" systems where the annotator has not previously been run.