### PR TITLE
Bring coverage to 100%

### DIFF
--- a/geoparser/__main__.py
+++ b/geoparser/__main__.py
@@ -5,5 +5,5 @@ def main():
     app()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/geoparser/db/extensions/spatialite/loader.py
+++ b/geoparser/db/extensions/spatialite/loader.py
@@ -90,5 +90,5 @@ def load_spatialite_extension(dbapi_connection, spatialite_path: Path):
         # Always disable extension loading for security
         try:
             dbapi_connection.enable_load_extension(False)
-        except Exception:
+        except Exception:  # pragma: no cover
             pass  # Ignore errors when disabling

--- a/geoparser/db/extensions/spellfix/loader.py
+++ b/geoparser/db/extensions/spellfix/loader.py
@@ -79,5 +79,5 @@ def load_spellfix_extension(dbapi_connection, spellfix_path: Path):
         # Always disable extension loading for security
         try:
             dbapi_connection.enable_load_extension(False)
-        except Exception:
+        except Exception:  # pragma: no cover
             pass  # Ignore errors when disabling

--- a/tests/unit/test_db/test_db.py
+++ b/tests/unit/test_db/test_db.py
@@ -139,3 +139,60 @@ class TestSetSqlitePragma:
                     _set_sqlite_pragma(connection, None)
 
         connection.close()
+
+    def test_raises_runtime_error_when_spellfix_not_found(self):
+        """Test that RuntimeError is raised when Spellfix library is not found."""
+        # Arrange
+        import sqlite3
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from geoparser.db.db import _set_sqlite_pragma
+
+        connection = sqlite3.connect(":memory:")
+
+        # Act & Assert
+        with patch(
+            "geoparser.db.db.get_spatialite_path",
+            return_value=Path("/fake/path/mod_spatialite.so"),
+        ):
+            with patch("geoparser.db.db.load_spatialite_extension"):
+                with patch("geoparser.db.db.get_spellfix_path", return_value=None):
+                    with pytest.raises(
+                        RuntimeError, match="Spellfix library not found"
+                    ):
+                        _set_sqlite_pragma(connection, None)
+
+        connection.close()
+
+    def test_raises_runtime_error_when_spellfix_fails_to_load(self):
+        """Test that RuntimeError is raised when Spellfix fails to load."""
+        # Arrange
+        import sqlite3
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from geoparser.db.db import _set_sqlite_pragma
+
+        connection = sqlite3.connect(":memory:")
+
+        # Act & Assert
+        with patch(
+            "geoparser.db.db.get_spatialite_path",
+            return_value=Path("/fake/path/mod_spatialite.so"),
+        ):
+            with patch("geoparser.db.db.load_spatialite_extension"):
+                with patch(
+                    "geoparser.db.db.get_spellfix_path",
+                    return_value=Path("/fake/path/spellfix.so"),
+                ):
+                    with patch(
+                        "geoparser.db.db.load_spellfix_extension",
+                        side_effect=Exception("Load failed"),
+                    ):
+                        with pytest.raises(
+                            RuntimeError, match="Failed to load Spellfix extension"
+                        ):
+                            _set_sqlite_pragma(connection, None)
+
+        connection.close()

--- a/tests/unit/test_gazetteer/test_installer/test_queries/test_spatial.py
+++ b/tests/unit/test_gazetteer/test_installer/test_queries/test_spatial.py
@@ -84,6 +84,20 @@ class TestSpatialOptimizerOptimizeJoinCondition:
         assert "search_frame = geometry1" in result
         assert "ST_Within(geometry1, table2.geometry2)" in result
 
+    def test_centroid_fallback_when_pattern_doesnt_match(self):
+        """Test _optimize_centroid_join returns original when pattern doesn't match."""
+        # Arrange
+        optimizer = SpatialOptimizer()
+        # Condition has ST_Centroid but doesn't match the expected pattern
+        # (e.g., malformed or unexpected structure)
+        condition = "ST_Centroid(table1.geom) AND other_condition"
+
+        # Act
+        result = optimizer._optimize_centroid_join(condition)
+
+        # Assert - Should return original condition unchanged
+        assert result == condition
+
     def test_returns_original_for_non_spatial_condition(self):
         """Test that non-spatial conditions are returned unchanged."""
         # Arrange

--- a/tests/unit/test_gazetteer/test_installer/test_stages/test_acquisition.py
+++ b/tests/unit/test_gazetteer/test_installer/test_stages/test_acquisition.py
@@ -664,3 +664,113 @@ class TestAcquisitionStageFindTargetFileQuiet:
 
             # Assert
             assert result == target_file
+
+
+@pytest.mark.unit
+class TestAcquisitionStageShouldSkipExtraction:
+    """Test AcquisitionStage._should_skip_extraction() method."""
+
+    def test_returns_true_for_local_directory_source(self):
+        """Test that extraction is skipped for local directories (not files)."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Arrange
+            stage = AcquisitionStage(Path(temp_dir))
+
+            # Local directory (not a file)
+            source_dir = Path(temp_dir) / "local_data"
+            source_dir.mkdir()
+
+            extraction_dir = Path(temp_dir) / "extraction"
+            extraction_dir.mkdir()
+
+            # Act - archive_path is a directory, not a file
+            result = stage._should_skip_extraction(
+                source_dir, extraction_dir, "target.csv"
+            )
+
+            # Assert - Should return True (skip extraction for directories)
+            assert result is True
+
+    def test_returns_true_when_extraction_dir_matches_target_and_is_newer(self):
+        """Test extraction skipped when extraction dir name matches target and is newer."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Arrange
+            stage = AcquisitionStage(Path(temp_dir))
+
+            archive_path = Path(temp_dir) / "archive.zip"
+            archive_path.write_text("archive content")
+
+            # Extraction directory with same name as target
+            extraction_dir = Path(temp_dir) / "mydata"
+            extraction_dir.mkdir()
+
+            # Make extraction dir newer than archive
+            import time
+
+            time.sleep(0.01)
+            extraction_dir.touch()
+
+            # Act
+            result = stage._should_skip_extraction(
+                archive_path, extraction_dir, "mydata"
+            )
+
+            # Assert
+            assert result is True
+
+    def test_returns_false_as_fallback(self):
+        """Test that False is returned when no cache conditions are met."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Arrange
+            stage = AcquisitionStage(Path(temp_dir))
+
+            archive_path = Path(temp_dir) / "archive.zip"
+            archive_path.write_text("archive content")
+
+            # Extraction directory with different name
+            extraction_dir = Path(temp_dir) / "extraction"
+            extraction_dir.mkdir()
+
+            # Make archive newer than extraction dir
+            import time
+
+            time.sleep(0.01)
+            archive_path.touch()
+
+            # Act - no target file exists, timestamps don't match
+            result = stage._should_skip_extraction(
+                archive_path, extraction_dir, "target.csv"
+            )
+
+            # Assert
+            assert result is False
+
+
+@pytest.mark.unit
+class TestAcquisitionStageExtractZip:
+    """Test AcquisitionStage._extract_zip() method."""
+
+    def test_removes_existing_extraction_directory(self):
+        """Test that existing extraction directory is removed before extraction."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Arrange
+            stage = AcquisitionStage(Path(temp_dir))
+
+            # Create archive
+            archive_path = Path(temp_dir) / "archive.zip"
+            with zipfile.ZipFile(archive_path, "w") as zf:
+                zf.writestr("target.csv", "new content")
+
+            # Create existing extraction directory with old content
+            extraction_dir = Path(temp_dir) / "archive"
+            extraction_dir.mkdir()
+            old_file = extraction_dir / "old.txt"
+            old_file.write_text("old content")
+
+            # Act
+            result = stage._extract_zip(archive_path, extraction_dir, "target.csv")
+
+            # Assert
+            assert not old_file.exists()  # Old file should be removed
+            assert result.exists()
+            assert result.read_text() == "new content"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -4,6 +4,8 @@ Unit tests for geoparser/__main__.py
 Tests the main entry point for the geoparser module.
 """
 
+import subprocess
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -24,3 +26,17 @@ class TestMain:
 
         # Assert
         mock_app.assert_called_once()
+
+    def test_main_module_execution(self):
+        """Test running the module directly with python -m geoparser."""
+        # Arrange & Act
+        result = subprocess.run(
+            [sys.executable, "-m", "geoparser", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+        # Assert
+        assert result.returncode == 0
+        assert "Usage:" in result.stdout or "usage:" in result.stdout.lower()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -30,11 +30,14 @@ class TestMain:
     def test_main_module_execution(self):
         """Test running the module directly with python -m geoparser."""
         # Arrange & Act
+        # Use longer timeout on Windows where subprocess can be slower
+        timeout = 60 if sys.platform == "win32" else 30
+
         result = subprocess.run(
             [sys.executable, "-m", "geoparser", "--help"],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=timeout,
         )
 
         # Assert


### PR DESCRIPTION
This small PR should increase test coverage to 100%. This is done in three main ways:
* Adding explicit tests for `AcquisitionStage._should_skip_extraction()` and `AcquisitionStage._extract_zip()` to cover handling of exceptions and edge cases.
* Testing `main()` in `geoparser/__main__.py` via subprocess. Because this cannot be tracked by coverage in the parent process, the line is excluded from coverage nonetheless.
* 2 additional lines with exception handling for disabling extensions (spellfix and spatialite in `loader.py`) are also excluded. These exception handlers guard against SQLite-internal failures. This allows us to exclude them in my opinion, as mocking such exceptions is a bit out of scope for this Python test suite. Feel free to challenge.