### PR TITLE
Rename gazetteer CLI to `install` and fix annotator recognizer API calls

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -17,8 +17,8 @@ RUN python -m spacy download en_core_web_sm && \
     python -m spacy download en_core_web_trf && \
     python -m spacy download xx_sent_ud_sm
 
-# Pre-download and install GeoNames gazetteer
-RUN python -m geoparser download geonames
+# Pre-install GeoNames gazetteer
+RUN python -m geoparser install geonames
 
 # Create workspace directory
 WORKDIR /workspace

--- a/docs/guides/gazetteers.rst
+++ b/docs/guides/gazetteers.rst
@@ -30,7 +30,7 @@ To install GeoNames Cities:
 
 .. code-block:: bash
 
-   python -m geoparser download geonames-cities
+   python -m geoparser install geonames-cities
 
 Installation typically completes within a few minutes.
 
@@ -45,7 +45,7 @@ To install GeoNames:
 
 .. code-block:: bash
 
-   python -m geoparser download geonames
+   python -m geoparser install geonames
 
 The installation process can take up to 20-40 minutes depending on your system.
 
@@ -58,7 +58,7 @@ To install SwissNames3D:
 
 .. code-block:: bash
 
-   python -m geoparser download swissnames3d
+   python -m geoparser install swissnames3d
 
 The installation process typically completes within a few minutes.
 
@@ -434,7 +434,7 @@ To install a custom gazetteer, provide the path to your configuration file:
 
 .. code-block:: bash
 
-   python -m geoparser download path/to/my_gazetteer.yaml
+   python -m geoparser install path/to/my_gazetteer.yaml
 
 The installer validates the configuration, downloads or locates the specified files, creates database tables according to the attribute specifications, loads the data, applies transformations and derivations, creates indices, and registers the gazetteer so it can be queried through the standard interface.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,7 +20,10 @@ Install the Irchel Geoparser using pip:
 Installing Gazetteers
 ---------------------
 
-The library requires gazetteer data to resolve toponyms to geographic locations. Gazetteers are stored in a SQLite database in your system's application data directory. You can install gazetteers using a single command that downloads the data and sets up the database automatically.
+The library requires gazetteer data to resolve toponyms to geographic locations. Gazetteers are stored in a SQLite database in your system's application data directory. You can install gazetteers using a single command that downloads the source data and sets up the database automatically.
+
+.. note::
+   The gazetteer CLI command was renamed from ``download`` to ``install``.
 
 If you want to try geoparsing quickly, start with **GeoNames Cities**, a lightweight subset that installs in a few minutes. For real geoparsing work, use the full **GeoNames** gazetteer instead: it covers far more than cities alone, including towns, natural features, landmarks, and fine-grained place names that the cities subset omits entirely.
 
@@ -37,7 +40,7 @@ If you want to try geoparsing quickly, start with **GeoNames Cities**, a lightwe
 
       .. code-block:: bash
 
-         python -m geoparser download geonames-cities
+         python -m geoparser install geonames-cities
 
       Installation typically completes within a few minutes. Many place types (towns, rivers, mountains, and so on) are not included at all. Use this gazetteer to experiment with the library; switch to full GeoNames for serious geoparsing.
 
@@ -52,7 +55,7 @@ If you want to try geoparsing quickly, start with **GeoNames Cities**, a lightwe
 
       .. code-block:: bash
 
-         python -m geoparser download geonames
+         python -m geoparser install geonames
 
       This command downloads the GeoNames data files, processes them, and creates the necessary database tables and indices. The process may take 20-40 minutes depending on your system.
 
@@ -67,7 +70,7 @@ If you want to try geoparsing quickly, start with **GeoNames Cities**, a lightwe
 
       .. code-block:: bash
 
-         python -m geoparser download swissnames3d
+         python -m geoparser install swissnames3d
 
       This command downloads the SwissNames3D data, processes it, and creates the database. The process typically completes within a few minutes.
 

--- a/geoparser/annotator/db/crud/document.py
+++ b/geoparser/annotator/db/crud/document.py
@@ -95,7 +95,7 @@ class DocumentRepository(BaseRepository):
             filename = secure_filename(file.filename)
             text = file.file.read().decode("utf-8")
             if apply_spacy and recognizer:
-                references = recognizer.predict_references([text])[0]
+                references = recognizer.predict([text])[0]
                 toponyms = [
                     AnnotatorToponymCreate(text=text[start:end], start=start, end=end)
                     for start, end in references
@@ -183,7 +183,7 @@ class DocumentRepository(BaseRepository):
     def parse(cls, db: DBSession, id: uuid.UUID) -> AnnotatorDocument:
         document = cls.read(db, id)
         recognizer = SpacyRecognizer(model_name=document.spacy_model)
-        references = recognizer.predict_references([document.text])[0]
+        references = recognizer.predict([document.text])[0]
         spacy_toponyms = [
             AnnotatorToponymCreate(text=document.text[start:end], start=start, end=end)
             for start, end in references

--- a/geoparser/cli/app.py
+++ b/geoparser/cli/app.py
@@ -2,7 +2,9 @@ import typer
 
 from geoparser.cli.annotator import annotator_cli
 from geoparser.cli.download import download_cli
+from geoparser.cli.install import install_cli
 
 app = typer.Typer()
 app.command("annotator")(annotator_cli)
-app.command("download")(download_cli)
+app.command("install")(install_cli)
+app.command("download", deprecated=True)(download_cli)

--- a/geoparser/cli/download.py
+++ b/geoparser/cli/download.py
@@ -1,54 +1,21 @@
-from importlib.resources import files
-from pathlib import Path
-
-from geoparser.gazetteer.installer.installer import GazetteerInstaller
-
-
-def _get_builtin_gazetteers() -> dict[str, Path]:
-    """
-    Discover all built-in gazetteer configurations.
-
-    Returns:
-        Dictionary mapping gazetteer names to their config file paths.
-    """
-    configs_dir = files("geoparser.gazetteer") / "configs"
-
-    # Get all yaml files in the configs directory
-    gazetteers = {}
-    for config_file in configs_dir.iterdir():
-        if config_file.name.endswith(".yaml"):
-            gazetteer_name = config_file.name[:-5]  # Remove .yaml extension
-            gazetteers[gazetteer_name] = Path(str(config_file))
-
-    return gazetteers
+import typer
 
 
 def download_cli(config: str):
     """
-    Download and install a gazetteer from a configuration file.
+    [Deprecated] This command has been renamed to ``install``.
+
+    Use ``install`` instead::
+
+        python -m geoparser install geonames
 
     Args:
         config: Either a gazetteer name (e.g., 'geonames', 'swissnames3d') or
                 a path to a custom YAML configuration file.
     """
-    # Check if config is a built-in gazetteer name
-    config_path = Path(config)
-
-    if not config_path.exists():
-        # Get available built-in gazetteers
-        builtin_gazetteers = _get_builtin_gazetteers()
-
-        if config in builtin_gazetteers:
-            config_path = builtin_gazetteers[config]
-        else:
-            available = "\n".join(
-                f"  - {name}" for name in sorted(builtin_gazetteers.keys())
-            )
-            raise FileNotFoundError(
-                f"Gazetteer config not found: {config}\n"
-                f"Available built-in gazetteer configs:\n{available}"
-            )
-
-    # Install the gazetteer
-    installer = GazetteerInstaller()
-    installer.install(config_path)
+    typer.secho(
+        f"Use 'install' instead:\n" f"  python -m geoparser install {config}",
+        fg=typer.colors.YELLOW,
+        err=True,
+    )
+    raise typer.Exit(code=1)

--- a/geoparser/cli/install.py
+++ b/geoparser/cli/install.py
@@ -1,0 +1,53 @@
+from importlib.resources import files
+from pathlib import Path
+
+from geoparser.gazetteer.installer.installer import GazetteerInstaller
+
+
+def _get_builtin_gazetteers() -> dict[str, Path]:
+    """
+    Discover all built-in gazetteer configurations.
+
+    Returns:
+        Dictionary mapping gazetteer names to their config file paths.
+    """
+    configs_dir = files("geoparser.gazetteer") / "configs"
+
+    # Get all yaml files in the configs directory
+    gazetteers = {}
+    for config_file in configs_dir.iterdir():
+        if config_file.name.endswith(".yaml"):
+            gazetteer_name = config_file.name[:-5]  # Remove .yaml extension
+            gazetteers[gazetteer_name] = Path(str(config_file))
+
+    return gazetteers
+
+
+def install_cli(config: str):
+    """
+    Install a gazetteer from a configuration file.
+
+    Args:
+        config: Either a gazetteer name (e.g., 'geonames', 'swissnames3d') or
+                a path to a custom YAML configuration file.
+    """
+    # Check if config is a built-in gazetteer name
+    config_path = Path(config)
+
+    if not config_path.exists():
+        # Get available built-in gazetteers
+        builtin_gazetteers = _get_builtin_gazetteers()
+
+        if config in builtin_gazetteers:
+            config_path = builtin_gazetteers[config]
+        else:
+            available = "\n".join(
+                f"  - {name}" for name in sorted(builtin_gazetteers.keys())
+            )
+            raise FileNotFoundError(
+                f"Gazetteer config not found: {config}\n"
+                f"Available built-in gazetteer configs:\n{available}"
+            )
+
+    installer = GazetteerInstaller()
+    installer.install(config_path)

--- a/geoparser/modules/recognizers/manual.py
+++ b/geoparser/modules/recognizers/manual.py
@@ -16,7 +16,7 @@ class ManualRecognizer(Recognizer):
     multiple annotation sets (e.g., from different annotators) to be stored
     for the same documents.
 
-    The annotations are provided at initialization and returned by predict_references()
+    The annotations are provided at initialization and returned by predict()
     in the same order as the input documents. The label is stored in the database
     config to differentiate between different annotation sets.
     """

--- a/geoparser/modules/resolvers/manual.py
+++ b/geoparser/modules/resolvers/manual.py
@@ -16,7 +16,7 @@ class ManualResolver(Resolver):
     a label, enabling multiple annotation sets (e.g., from different annotators)
     to be stored for the same references.
 
-    The annotations are provided at initialization and returned by predict_referents()
+    The annotations are provided at initialization and returned by predict()
     in the same order as the input references. The label is stored in the database
     config to differentiate between different annotation sets.
     """

--- a/tests/unit/test_cli/test_app.py
+++ b/tests/unit/test_cli/test_app.py
@@ -31,8 +31,19 @@ class TestCliApp:
         # Assert
         assert "annotator" in commands
 
-    def test_app_has_download_command(self):
-        """Test that app has download command registered."""
+    def test_app_has_install_command(self):
+        """Test that app has install command registered."""
+        # Arrange
+        from geoparser.cli.app import app
+
+        # Act - Get registered commands
+        commands = {cmd.name: cmd for cmd in app.registered_commands}
+
+        # Assert
+        assert "install" in commands
+
+    def test_app_has_download_command_as_deprecated_alias(self):
+        """Test that app keeps download registered as deprecated."""
         # Arrange
         from geoparser.cli.app import app
 
@@ -41,3 +52,4 @@ class TestCliApp:
 
         # Assert
         assert "download" in commands
+        assert commands["download"].deprecated is True

--- a/tests/unit/test_cli/test_download.py
+++ b/tests/unit/test_cli/test_download.py
@@ -1,197 +1,38 @@
 """
 Unit tests for geoparser/cli/download.py
 
-Tests the download CLI functionality.
+Tests the deprecated download CLI command.
 """
 
-from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
-
-
-@pytest.mark.unit
-class TestGetBuiltinGazetteers:
-    """Test _get_builtin_gazetteers() function."""
-
-    @patch("geoparser.cli.download.files")
-    def test_discovers_yaml_files_in_configs_directory(self, mock_files):
-        """Test that YAML files are discovered from configs directory."""
-        # Arrange
-        from geoparser.cli.download import _get_builtin_gazetteers
-
-        mock_configs_dir = Mock()
-        mock_files.return_value.__truediv__.return_value = mock_configs_dir
-
-        mock_yaml1 = Mock()
-        mock_yaml1.name = "geonames.yaml"
-        mock_yaml2 = Mock()
-        mock_yaml2.name = "swissnames3d.yaml"
-        mock_txt = Mock()
-        mock_txt.name = "readme.txt"
-
-        mock_configs_dir.iterdir.return_value = [mock_yaml1, mock_yaml2, mock_txt]
-
-        # Act
-        result = _get_builtin_gazetteers()
-
-        # Assert
-        assert "geonames" in result
-        assert "swissnames3d" in result
-        assert "readme" not in result  # Non-YAML files should be excluded
-
-    @patch("geoparser.cli.download.files")
-    def test_returns_empty_dict_when_no_yaml_files(self, mock_files):
-        """Test that empty dict is returned when no YAML files found."""
-        # Arrange
-        from geoparser.cli.download import _get_builtin_gazetteers
-
-        mock_configs_dir = Mock()
-        mock_files.return_value.__truediv__.return_value = mock_configs_dir
-        mock_configs_dir.iterdir.return_value = []
-
-        # Act
-        result = _get_builtin_gazetteers()
-
-        # Assert
-        assert result == {}
-
-    @patch("geoparser.cli.download.files")
-    def test_strips_yaml_extension_from_names(self, mock_files):
-        """Test that .yaml extension is stripped from gazetteer names."""
-        # Arrange
-        from geoparser.cli.download import _get_builtin_gazetteers
-
-        mock_configs_dir = Mock()
-        mock_files.return_value.__truediv__.return_value = mock_configs_dir
-
-        mock_yaml = Mock()
-        mock_yaml.name = "my_gazetteer.yaml"
-        mock_configs_dir.iterdir.return_value = [mock_yaml]
-
-        # Act
-        result = _get_builtin_gazetteers()
-
-        # Assert
-        assert "my_gazetteer" in result
-        assert "my_gazetteer.yaml" not in result
+import typer
 
 
 @pytest.mark.unit
 class TestDownloadCli:
-    """Test download_cli() function."""
+    """Test deprecated download_cli() command."""
 
-    @patch("geoparser.cli.download.GazetteerInstaller")
-    @patch("geoparser.cli.download.Path")
-    def test_installs_from_existing_file_path(self, mock_path_class, mock_installer):
-        """Test that gazetteer is installed when config file exists."""
-        # Arrange
+    @patch("geoparser.cli.download.typer.secho")
+    def test_does_not_install_gazetteer(self, mock_secho):
+        """Test that download_cli does not install a gazetteer."""
         from geoparser.cli.download import download_cli
 
-        mock_path = Mock()
-        mock_path.exists.return_value = True
-        mock_path_class.return_value = mock_path
+        with pytest.raises(typer.Exit) as exc_info:
+            download_cli("geonames")
 
-        mock_installer_instance = Mock()
-        mock_installer.return_value = mock_installer_instance
+        assert exc_info.value.exit_code == 1
 
-        # Act
-        download_cli("path/to/config.yaml")
-
-        # Assert
-        mock_installer_instance.install.assert_called_once_with(mock_path)
-
-    @patch("geoparser.cli.download.GazetteerInstaller")
-    @patch("geoparser.cli.download._get_builtin_gazetteers")
-    @patch("geoparser.cli.download.Path")
-    def test_uses_builtin_gazetteer_when_name_matches(
-        self, mock_path_class, mock_get_builtin, mock_installer
-    ):
-        """Test that built-in gazetteer is used when name matches."""
-        # Arrange
+    @patch("geoparser.cli.download.typer.secho")
+    def test_prints_install_command(self, mock_secho):
+        """Test that download_cli prints the replacement install command."""
         from geoparser.cli.download import download_cli
 
-        mock_path = Mock()
-        mock_path.exists.return_value = False
-        mock_path_class.return_value = mock_path
+        with pytest.raises(typer.Exit):
+            download_cli("geonames")
 
-        builtin_path = Path("/builtin/geonames.yaml")
-        mock_get_builtin.return_value = {"geonames": builtin_path}
-
-        mock_installer_instance = Mock()
-        mock_installer.return_value = mock_installer_instance
-
-        # Act
-        download_cli("geonames")
-
-        # Assert
-        mock_installer_instance.install.assert_called_once_with(builtin_path)
-
-    @patch("geoparser.cli.download._get_builtin_gazetteers")
-    @patch("geoparser.cli.download.Path")
-    def test_raises_error_when_config_not_found(
-        self, mock_path_class, mock_get_builtin
-    ):
-        """Test that FileNotFoundError is raised when config doesn't exist."""
-        # Arrange
-        from geoparser.cli.download import download_cli
-
-        mock_path = Mock()
-        mock_path.exists.return_value = False
-        mock_path_class.return_value = mock_path
-
-        mock_get_builtin.return_value = {"geonames": Path("/builtin/geonames.yaml")}
-
-        # Act & Assert
-        with pytest.raises(FileNotFoundError, match="Gazetteer config not found"):
-            download_cli("nonexistent")
-
-    @patch("geoparser.cli.download._get_builtin_gazetteers")
-    @patch("geoparser.cli.download.Path")
-    def test_error_message_lists_available_gazetteers(
-        self, mock_path_class, mock_get_builtin
-    ):
-        """Test that error message lists available built-in gazetteers."""
-        # Arrange
-        from geoparser.cli.download import download_cli
-
-        mock_path = Mock()
-        mock_path.exists.return_value = False
-        mock_path_class.return_value = mock_path
-
-        mock_get_builtin.return_value = {
-            "geonames": Path("/builtin/geonames.yaml"),
-            "swissnames3d": Path("/builtin/swissnames3d.yaml"),
-        }
-
-        # Act & Assert
-        with pytest.raises(FileNotFoundError) as exc_info:
-            download_cli("nonexistent")
-
-        error_message = str(exc_info.value)
-        assert "geonames" in error_message
-        assert "swissnames3d" in error_message
-        assert "Available built-in gazetteer configs" in error_message
-
-    @patch("geoparser.cli.download.GazetteerInstaller")
-    @patch("geoparser.cli.download._get_builtin_gazetteers")
-    @patch("geoparser.cli.download.Path")
-    def test_creates_installer_instance(
-        self, mock_path_class, mock_get_builtin, mock_installer
-    ):
-        """Test that GazetteerInstaller is instantiated."""
-        # Arrange
-        from geoparser.cli.download import download_cli
-
-        mock_path = Mock()
-        mock_path.exists.return_value = True
-        mock_path_class.return_value = mock_path
-
-        mock_installer_instance = Mock()
-        mock_installer.return_value = mock_installer_instance
-
-        # Act
-        download_cli("path/to/config.yaml")
-
-        # Assert
-        mock_installer.assert_called_once()
+        mock_secho.assert_called_once()
+        message = mock_secho.call_args[0][0]
+        assert "install" in message.lower()
+        assert "geonames" in message

--- a/tests/unit/test_cli/test_install.py
+++ b/tests/unit/test_cli/test_install.py
@@ -1,0 +1,197 @@
+"""
+Unit tests for geoparser/cli/install.py
+
+Tests the install CLI functionality.
+"""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+@pytest.mark.unit
+class TestGetBuiltinGazetteers:
+    """Test _get_builtin_gazetteers() function."""
+
+    @patch("geoparser.cli.install.files")
+    def test_discovers_yaml_files_in_configs_directory(self, mock_files):
+        """Test that YAML files are discovered from configs directory."""
+        # Arrange
+        from geoparser.cli.install import _get_builtin_gazetteers
+
+        mock_configs_dir = Mock()
+        mock_files.return_value.__truediv__.return_value = mock_configs_dir
+
+        mock_yaml1 = Mock()
+        mock_yaml1.name = "geonames.yaml"
+        mock_yaml2 = Mock()
+        mock_yaml2.name = "swissnames3d.yaml"
+        mock_txt = Mock()
+        mock_txt.name = "readme.txt"
+
+        mock_configs_dir.iterdir.return_value = [mock_yaml1, mock_yaml2, mock_txt]
+
+        # Act
+        result = _get_builtin_gazetteers()
+
+        # Assert
+        assert "geonames" in result
+        assert "swissnames3d" in result
+        assert "readme" not in result  # Non-YAML files should be excluded
+
+    @patch("geoparser.cli.install.files")
+    def test_returns_empty_dict_when_no_yaml_files(self, mock_files):
+        """Test that empty dict is returned when no YAML files found."""
+        # Arrange
+        from geoparser.cli.install import _get_builtin_gazetteers
+
+        mock_configs_dir = Mock()
+        mock_files.return_value.__truediv__.return_value = mock_configs_dir
+        mock_configs_dir.iterdir.return_value = []
+
+        # Act
+        result = _get_builtin_gazetteers()
+
+        # Assert
+        assert result == {}
+
+    @patch("geoparser.cli.install.files")
+    def test_strips_yaml_extension_from_names(self, mock_files):
+        """Test that .yaml extension is stripped from gazetteer names."""
+        # Arrange
+        from geoparser.cli.install import _get_builtin_gazetteers
+
+        mock_configs_dir = Mock()
+        mock_files.return_value.__truediv__.return_value = mock_configs_dir
+
+        mock_yaml = Mock()
+        mock_yaml.name = "my_gazetteer.yaml"
+        mock_configs_dir.iterdir.return_value = [mock_yaml]
+
+        # Act
+        result = _get_builtin_gazetteers()
+
+        # Assert
+        assert "my_gazetteer" in result
+        assert "my_gazetteer.yaml" not in result
+
+
+@pytest.mark.unit
+class TestInstallCli:
+    """Test install_cli() function."""
+
+    @patch("geoparser.cli.install.GazetteerInstaller")
+    @patch("geoparser.cli.install.Path")
+    def test_installs_from_existing_file_path(self, mock_path_class, mock_installer):
+        """Test that gazetteer is installed when config file exists."""
+        # Arrange
+        from geoparser.cli.install import install_cli
+
+        mock_path = Mock()
+        mock_path.exists.return_value = True
+        mock_path_class.return_value = mock_path
+
+        mock_installer_instance = Mock()
+        mock_installer.return_value = mock_installer_instance
+
+        # Act
+        install_cli("path/to/config.yaml")
+
+        # Assert
+        mock_installer_instance.install.assert_called_once_with(mock_path)
+
+    @patch("geoparser.cli.install.GazetteerInstaller")
+    @patch("geoparser.cli.install._get_builtin_gazetteers")
+    @patch("geoparser.cli.install.Path")
+    def test_uses_builtin_gazetteer_when_name_matches(
+        self, mock_path_class, mock_get_builtin, mock_installer
+    ):
+        """Test that built-in gazetteer is used when name matches."""
+        # Arrange
+        from geoparser.cli.install import install_cli
+
+        mock_path = Mock()
+        mock_path.exists.return_value = False
+        mock_path_class.return_value = mock_path
+
+        builtin_path = Path("/builtin/geonames.yaml")
+        mock_get_builtin.return_value = {"geonames": builtin_path}
+
+        mock_installer_instance = Mock()
+        mock_installer.return_value = mock_installer_instance
+
+        # Act
+        install_cli("geonames")
+
+        # Assert
+        mock_installer_instance.install.assert_called_once_with(builtin_path)
+
+    @patch("geoparser.cli.install._get_builtin_gazetteers")
+    @patch("geoparser.cli.install.Path")
+    def test_raises_error_when_config_not_found(
+        self, mock_path_class, mock_get_builtin
+    ):
+        """Test that FileNotFoundError is raised when config doesn't exist."""
+        # Arrange
+        from geoparser.cli.install import install_cli
+
+        mock_path = Mock()
+        mock_path.exists.return_value = False
+        mock_path_class.return_value = mock_path
+
+        mock_get_builtin.return_value = {"geonames": Path("/builtin/geonames.yaml")}
+
+        # Act & Assert
+        with pytest.raises(FileNotFoundError, match="Gazetteer config not found"):
+            install_cli("nonexistent")
+
+    @patch("geoparser.cli.install._get_builtin_gazetteers")
+    @patch("geoparser.cli.install.Path")
+    def test_error_message_lists_available_gazetteers(
+        self, mock_path_class, mock_get_builtin
+    ):
+        """Test that error message lists available built-in gazetteers."""
+        # Arrange
+        from geoparser.cli.install import install_cli
+
+        mock_path = Mock()
+        mock_path.exists.return_value = False
+        mock_path_class.return_value = mock_path
+
+        mock_get_builtin.return_value = {
+            "geonames": Path("/builtin/geonames.yaml"),
+            "swissnames3d": Path("/builtin/swissnames3d.yaml"),
+        }
+
+        # Act & Assert
+        with pytest.raises(FileNotFoundError) as exc_info:
+            install_cli("nonexistent")
+
+        error_message = str(exc_info.value)
+        assert "geonames" in error_message
+        assert "swissnames3d" in error_message
+        assert "Available built-in gazetteer configs" in error_message
+
+    @patch("geoparser.cli.install.GazetteerInstaller")
+    @patch("geoparser.cli.install._get_builtin_gazetteers")
+    @patch("geoparser.cli.install.Path")
+    def test_creates_installer_instance(
+        self, mock_path_class, mock_get_builtin, mock_installer
+    ):
+        """Test that GazetteerInstaller is instantiated."""
+        # Arrange
+        from geoparser.cli.install import install_cli
+
+        mock_path = Mock()
+        mock_path.exists.return_value = True
+        mock_path_class.return_value = mock_path
+
+        mock_installer_instance = Mock()
+        mock_installer.return_value = mock_installer_instance
+
+        # Act
+        install_cli("path/to/config.yaml")
+
+        # Assert
+        mock_installer.assert_called_once()


### PR DESCRIPTION
This PR tidies up two loose ends from recent refactors. The gazetteer setup command is renamed from `download` to `install`, which better reflects what it does: it downloads source data and builds the local gazetteer database.

The second change fixes a regression in the Annotator where `DocumentRepository` still called `predict_references()` on `SpacyRecognizer`, a method removed when recognizers were unified under `predict()` (#90).