### PR TITLE
Require explicit Geoparser modules, return document IDs, and add architecture roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ pip install geoparser
 
 ```python
 from geoparser import Geoparser
+from geoparser.modules import SentenceTransformerResolver, SpacyRecognizer
 
-# Initialize with default settings
-gp = Geoparser()
+# Build a pipeline from a recognizer and a resolver
+gp = Geoparser(
+    recognizer=SpacyRecognizer(),
+    resolver=SentenceTransformerResolver(gazetteer_name="geonames"),
+)
 
 # Parse text
 text = "Paris is the capital of France."

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Full documentation is available at **[docs.geoparser.app](https://docs.geoparser
 - [User Guides](https://docs.geoparser.app/en/latest/guides/projects.html)
 - [API Reference](https://docs.geoparser.app/en/latest/api/geoparser.html)
 
+## Roadmap
+
+Larger changes we intend to make — splitting the gazetteer and the default modules into standalone packages, and rethinking how documents and results are passed in and out — are described in [ROADMAP.md](ROADMAP.md).
+
 ## Contributing
 
 Questions, bug reports, and ideas are always welcome via [issues](https://github.com/dguzh/geoparser/issues). Pull requests are appreciated too — see [CONTRIBUTING.md](CONTRIBUTING.md) for local setup and development guidelines.

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ gp = Geoparser(
 
 # Parse text
 text = "Paris is the capital of France."
-docs = gp.parse(text)
+doc = gp.parse(text)
 
 # Access results
-for toponym in docs[0].toponyms:
+for toponym in doc.toponyms:
     print(f"{toponym.text} -> {toponym.location.data}")
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,17 @@
+# Roadmap
+
+This file collects the larger changes we intend to make to the Irchel Geoparser. They are directions rather than scheduled work, and none of them are needed to use the library as it is today. Feedback on any of them is welcome in the [issue tracker](https://github.com/dguzh/geoparser/issues).
+
+## Modular packaging
+
+`pip install geoparser` currently installs everything: the project layer, the gazetteer subsystem, and a full machine learning stack that exists only to support the two built-in modules. We want the core package to be the architecture itself (the recognizer and resolver interfaces and the machinery around them), with implementations distributed separately.
+
+The gazetteer subsystem is the first candidate for this. Turning arbitrary geographic data into a single-file, uniformly queryable artifact is useful beyond geoparsing, and it should be usable without installing the geoparsing framework alongside it. Resolvers already reach gazetteers only through a small query interface, so the split is mainly a packaging exercise.
+
+The default recognizer and resolver would follow, moving spaCy, PyTorch and Transformers out of a minimal install and leaving lightweight implementations in the core that are sufficient for a complete example. A pipeline now already has to be assembled from modules explicitly, so no part of the library silently assumes that a particular implementation is installed.
+
+## Data handling
+
+Results are currently persisted in a database, and even the simple parse interface goes through a project under the hood. Persistence is genuinely useful for comparing runs over the same material, but we now think making it the core data model is the wrong default for an NLP library. Tools in this space are usually pipeline-shaped: text goes in, annotations come out, and persistence is left to the user.
+
+We intend to rethink input and output along those lines. Toponym annotations and texts are usually lightweight, so an in-memory representation is likely practical even for sizeable corpora, with a database becoming one optional backend rather than the pipeline itself.

--- a/docs/guides/projects.rst
+++ b/docs/guides/projects.rst
@@ -29,7 +29,7 @@ Once created, a project persists in the database until explicitly deleted. You c
 Adding Documents
 ----------------
 
-After creating a project, you can add documents to it using the ``create_documents()`` method. This method accepts either a single text string or a list of text strings:
+After creating a project, you can add documents to it using the ``create_documents()`` method. This method takes a list of text strings, one per document:
 
 .. code-block:: python
 
@@ -38,7 +38,7 @@ After creating a project, you can add documents to it using the ``create_documen
    project = Project("news_analysis")
 
    # Add a single document
-   project.create_documents("The summit took place in Geneva.")
+   project.create_documents(["The summit took place in Geneva."])
 
    # Add multiple documents
    texts = [

--- a/docs/guides/projects.rst
+++ b/docs/guides/projects.rst
@@ -48,7 +48,31 @@ After creating a project, you can add documents to it using the ``create_documen
    ]
    project.create_documents(texts)
 
-Documents added to a project are stored in the database with unique identifiers. You can add more documents to the same project at any time, and they will accumulate in the project's collection.
+You can add more documents to the same project at any time, and they will accumulate in the project's collection.
+
+Each document is stored under a unique identifier, and ``create_documents()`` returns those identifiers in the order the texts were given. If the texts come from an existing collection of yours — a database of articles, a set of files, or anything else — store the returned IDs with those records so that parsed results can later be matched to the originals:
+
+.. code-block:: python
+
+   articles = load_articles()  # your own records, whatever shape they have
+
+   document_ids = project.create_documents([article["body"] for article in articles])
+
+   for article, document_id in zip(articles, document_ids):
+       article["document_id"] = document_id
+
+Passing those IDs to ``get_documents()`` retrieves exactly those documents, in the order you asked for them:
+
+.. code-block:: python
+
+   # Results for one specific article
+   documents = project.get_documents(ids=article["document_id"])
+
+   # Or for a subset of your material, in your own order
+   recent = [article["document_id"] for article in articles if article["year"] >= 2020]
+   documents = project.get_documents(ids=recent)
+
+This makes it possible to work with parts of a corpus separately, for instance to compare how a pipeline performs on older versus newer material, without reprocessing anything.
 
 Running Processing Modules
 ---------------------------
@@ -87,6 +111,9 @@ After running modules on your project, you can retrieve the processed documents 
 
    # Get all documents with their results
    documents = project.get_documents()
+
+   # Or only specific ones, using the IDs from create_documents()
+   documents = project.get_documents(ids=document_ids)
 
    # Access the results
    for doc in documents:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,11 @@ Demo
 
 Discover what is possible with the Irchel Geoparser. Our :doc:`demo` page showcases an interactive visualization of place names mentioned in Jules Verne's "Around the World in Eighty Days". The demo includes a complete Jupyter notebook and Docker setup so you can reproduce the analysis yourself.
 
+Roadmap
+-------
+
+The library is under active development, and its architecture is expected to evolve: we plan to separate the gazetteer subsystem and the heavyweight default modules into standalone packages, and to rethink how documents and results are passed in and out. The `roadmap <https://github.com/dguzh/geoparser/blob/main/ROADMAP.md>`_ describes these directions in more detail.
+
 Contributing
 ------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -25,21 +25,20 @@ Here's a minimal working example, which assumes the ``geonames`` gazetteer has b
 
    # Parse a text
    text = "The Eiffel Tower in Paris attracts millions of visitors each year."
-   documents = geoparser.parse(text)
+   document = geoparser.parse(text)
 
    # Access the results
-   for doc in documents:
-       print(f"Document: {doc.text}\n")
-       for toponym in doc.toponyms:
-           print(f"  Toponym: {toponym.text}")
-           if toponym.location:
-               location = toponym.location
-               print(f"    Name: {location.data.get('name')}")
-               print(f"    Country: {location.data.get('country_name')}")
-               print(f"    Coordinates: ({location.data.get('latitude')}, {location.data.get('longitude')})")
-           else:
-               print("    Location: Could not be resolved")
-           print()
+   print(f"Document: {document.text}\n")
+   for toponym in document.toponyms:
+       print(f"  Toponym: {toponym.text}")
+       if toponym.location:
+           location = toponym.location
+           print(f"    Name: {location.data.get('name')}")
+           print(f"    Country: {location.data.get('country_name')}")
+           print(f"    Coordinates: ({location.data.get('latitude')}, {location.data.get('longitude')})")
+       else:
+           print("    Location: Could not be resolved")
+       print()
 
 This code identifies place names in the text and links them to geographic locations in the GeoNames gazetteer. The output might look like:
 
@@ -60,7 +59,7 @@ This code identifies place names in the text and links them to geographic locati
 Processing Multiple Documents
 ------------------------------
 
-The ``parse()`` method accepts both a single text string and a list of texts. Processing multiple documents together enables efficient batch processing:
+The ``parse()`` method accepts a list of texts as well as a single text string, and the result mirrors what was passed in: a single text is parsed into a single ``Document``, while a list of texts is parsed into a list of ``Document`` objects. Processing multiple documents together enables efficient batch processing:
 
 .. code-block:: python
 
@@ -90,7 +89,7 @@ The ``parse()`` method accepts both a single text string and a list of texts. Pr
 Understanding the Results
 --------------------------
 
-The ``parse()`` method returns a list of ``Document`` objects in the same order as the input texts, so results can be related back to whatever the texts came from. Each document has a ``toponyms`` property that provides access to the identified place names (references) within that document.
+A single text is parsed into a single ``Document``, which the first example above works with directly. A list of texts is parsed into a list of ``Document`` objects in the same order as the input texts, so results can be related back to whatever the texts came from. Either way, each document has a ``toponyms`` property that provides access to the identified place names (references) within that document.
 
 Each toponym (``Reference`` object) has several important properties:
 
@@ -118,15 +117,14 @@ Not all identified place names can be successfully linked to geographic location
        recognizer=SpacyRecognizer(),
        resolver=SentenceTransformerResolver(gazetteer_name="geonames"),
    )
-   documents = geoparser.parse("They traveled from Atlantis to Wonderland.")
+   document = geoparser.parse("They traveled from Atlantis to Wonderland.")
 
-   for doc in documents:
-       for toponym in doc.toponyms:
-           print(f"Toponym: {toponym.text}")
-           if toponym.location:
-               print(f"  Resolved to: {toponym.location.data.get('name')}")
-           else:
-               print("  Could not be resolved (fictional location)")
+   for toponym in document.toponyms:
+       print(f"Toponym: {toponym.text}")
+       if toponym.location:
+           print(f"  Resolved to: {toponym.location.data.get('name')}")
+       else:
+           print("  Could not be resolved (fictional location)")
 
 .. _customizing-geoparser:
 
@@ -148,7 +146,7 @@ The examples above use ``SpacyRecognizer`` and ``SentenceTransformerResolver`` w
 
    geoparser = Geoparser(recognizer=recognizer, resolver=resolver)
    
-   documents = geoparser.parse("Zurich is the largest city in Switzerland.")
+   document = geoparser.parse("Zurich is the largest city in Switzerland.")
 
 For more details on working with different modules, see the :doc:`guides/modules` guide.
 
@@ -166,7 +164,7 @@ By default, the ``parse()`` method creates a temporary project internally and de
        recognizer=SpacyRecognizer(),
        resolver=SentenceTransformerResolver(gazetteer_name="geonames"),
    )
-   documents = geoparser.parse("Berlin is the capital of Germany.", save=True)
+   document = geoparser.parse("Berlin is the capital of Germany.", save=True)
    # Results saved under project name: a1b2c3d4
 
 When ``save=True``, the method prints the project name that was created. You can later access these results using the ``Project`` class, as described in the :doc:`guides/projects` guide.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -8,16 +8,20 @@ This guide provides a quick introduction to using the Irchel Geoparser for basic
 Basic Usage
 -----------
 
-The simplest way to use the library is through the ``Geoparser`` class, which provides a stateless interface for quick geoparsing tasks. The default settings are optimized for English texts, prioritizing speed over accuracy. See the :ref:`customizing-geoparser` section below for other options.
+The simplest way to use the library is through the ``Geoparser`` class, which provides a stateless interface for quick geoparsing tasks. A geoparser is built from two modules that you provide explicitly: a recognizer that finds place names, and a resolver that links them to a gazetteer. The modules used below are optimized for English texts, prioritizing speed over accuracy. See the :ref:`customizing-geoparser` section for other options.
 
-Here's a minimal working example:
+Here's a minimal working example, which assumes the ``geonames`` gazetteer has been installed as described in the :doc:`installation` guide:
 
 .. code-block:: python
 
    from geoparser import Geoparser
+   from geoparser.modules import SentenceTransformerResolver, SpacyRecognizer
 
-   # Initialize the geoparser with default settings
-   geoparser = Geoparser()
+   # Initialize the geoparser with a recognizer and a resolver
+   geoparser = Geoparser(
+       recognizer=SpacyRecognizer(),
+       resolver=SentenceTransformerResolver(gazetteer_name="geonames"),
+   )
 
    # Parse a text
    text = "The Eiffel Tower in Paris attracts millions of visitors each year."
@@ -61,8 +65,12 @@ The ``parse()`` method accepts both a single text string and a list of texts. Pr
 .. code-block:: python
 
    from geoparser import Geoparser
+   from geoparser.modules import SentenceTransformerResolver, SpacyRecognizer
 
-   geoparser = Geoparser()
+   geoparser = Geoparser(
+       recognizer=SpacyRecognizer(),
+       resolver=SentenceTransformerResolver(gazetteer_name="geonames"),
+   )
 
    texts = [
        "London is the capital of the United Kingdom.",
@@ -82,7 +90,7 @@ The ``parse()`` method accepts both a single text string and a list of texts. Pr
 Understanding the Results
 --------------------------
 
-The ``parse()`` method returns a list of ``Document`` objects, each representing one of the input texts. Each document has a ``toponyms`` property that provides access to the identified place names (references) within that document.
+The ``parse()`` method returns a list of ``Document`` objects in the same order as the input texts, so results can be related back to whatever the texts came from. Each document has a ``toponyms`` property that provides access to the identified place names (references) within that document.
 
 Each toponym (``Reference`` object) has several important properties:
 
@@ -104,8 +112,12 @@ Not all identified place names can be successfully linked to geographic location
 .. code-block:: python
 
    from geoparser import Geoparser
+   from geoparser.modules import SentenceTransformerResolver, SpacyRecognizer
 
-   geoparser = Geoparser()
+   geoparser = Geoparser(
+       recognizer=SpacyRecognizer(),
+       resolver=SentenceTransformerResolver(gazetteer_name="geonames"),
+   )
    documents = geoparser.parse("They traveled from Atlantis to Wonderland.")
 
    for doc in documents:
@@ -121,7 +133,7 @@ Not all identified place names can be successfully linked to geographic location
 Customizing the Geoparser
 --------------------------
 
-The default ``Geoparser()`` uses a spaCy model for recognition and a SentenceTransformer model for resolution. You can customize these components by providing your own module instances:
+The examples above use ``SpacyRecognizer`` and ``SentenceTransformerResolver`` with their default settings. Both modules take parameters of their own, so a geoparser can be tailored to the language, domain, and gazetteer you work with:
 
 .. code-block:: python
 
@@ -148,8 +160,12 @@ By default, the ``parse()`` method creates a temporary project internally and de
 .. code-block:: python
 
    from geoparser import Geoparser
+   from geoparser.modules import SentenceTransformerResolver, SpacyRecognizer
 
-   geoparser = Geoparser()
+   geoparser = Geoparser(
+       recognizer=SpacyRecognizer(),
+       resolver=SentenceTransformerResolver(gazetteer_name="geonames"),
+   )
    documents = geoparser.parse("Berlin is the capital of Germany.", save=True)
    # Results saved under project name: a1b2c3d4
 

--- a/geoparser/db/crud/document.py
+++ b/geoparser/db/crud/document.py
@@ -28,3 +28,34 @@ class DocumentRepository(BaseRepository[Document]):
         """
         statement = select(Document).where(Document.project_id == project_id)
         return db.exec(statement).unique().all()
+
+    @classmethod
+    def get_by_ids(
+        cls, db: Session, project_id: uuid.UUID, ids: t.Sequence[uuid.UUID]
+    ) -> t.List[Document]:
+        """
+        Get the documents with the given IDs that belong to a project.
+
+        IDs that do not exist or belong to another project are ignored, and the
+        results are returned in no particular order.
+
+        Args:
+            db: Database session
+            project_id: Project ID
+            ids: Document IDs to retrieve
+
+        Returns:
+            List of documents
+        """
+        documents = []
+
+        # Query in chunks to stay below the SQLite limit on bound parameters
+        chunk_size = 500
+        for offset in range(0, len(ids), chunk_size):
+            chunk = ids[offset : offset + chunk_size]
+            statement = select(Document).where(
+                Document.project_id == project_id, Document.id.in_(chunk)
+            )
+            documents.extend(db.exec(statement).unique().all())
+
+        return documents

--- a/geoparser/gazetteer/gazetteer.py
+++ b/geoparser/gazetteer/gazetteer.py
@@ -37,7 +37,11 @@ class Gazetteer:
         """
         path = artifact_path(gazetteer_name)
         if not path.exists():
-            raise ValueError(f"Gazetteer '{gazetteer_name}' is not installed.")
+            raise ValueError(
+                f"Gazetteer '{gazetteer_name}' is not installed. Install it by running "
+                f"'python -m geoparser install {gazetteer_name}', or run "
+                "'python -m geoparser list' to see which gazetteers are installed."
+            )
         self.gazetteer_name = gazetteer_name
         self._artifact = GazetteerArtifact(path)
 

--- a/geoparser/geoparser/geoparser.py
+++ b/geoparser/geoparser/geoparser.py
@@ -1,14 +1,10 @@
 import uuid
-import warnings
 from typing import List, Optional, Union
 
 from geoparser.db.models import Document
 from geoparser.modules.recognizers import Recognizer
 from geoparser.modules.resolvers import Resolver
 from geoparser.project import Project
-
-# Sentinel value to distinguish "not provided" from "explicitly None"
-_UNSET = object()
 
 
 class Geoparser:
@@ -17,127 +13,35 @@ class Geoparser:
 
     Provides a simple parse method for processing texts with configured recognizer and resolver.
     The Geoparser creates a new project for each parse operation, making it stateless by default.
+
+    The recognizer and resolver have to be provided explicitly, so that it is
+    always clear which modules a pipeline is built from::
+
+        from geoparser import Geoparser
+        from geoparser.modules import SentenceTransformerResolver, SpacyRecognizer
+
+        geoparser = Geoparser(
+            recognizer=SpacyRecognizer(),
+            resolver=SentenceTransformerResolver(gazetteer_name="geonames"),
+        )
     """
 
     def __init__(
         self,
-        recognizer: Optional[Recognizer] = _UNSET,
-        resolver: Optional[Resolver] = _UNSET,
-        spacy_model: Optional[str] = None,
-        transformer_model: Optional[str] = None,
+        recognizer: Optional[Recognizer],
+        resolver: Optional[Resolver],
     ):
         """
         Initialize a Geoparser instance.
 
         Args:
-            recognizer: The recognizer module to use for identifying references.
-                       If not provided, a default SpacyRecognizer will be created.
-                       Can be explicitly set to None to skip recognition step.
-            resolver: The resolver module to use for resolving references to referents.
-                     If not provided, a default SentenceTransformerResolver will be created.
-                     Can be explicitly set to None to skip resolution step.
-            spacy_model: (Deprecated) Name of spaCy model to use.
-                        Use SpacyRecognizer(model_name='...') instead.
-            transformer_model: (Deprecated) Name of transformer model to use.
-                              Use SentenceTransformerResolver(model_name='...') instead.
+            recognizer: The recognizer module to use for identifying references,
+                        or None to skip the recognition step.
+            resolver: The resolver module to use for resolving references to referents,
+                      or None to skip the resolution step.
         """
-        # Handle legacy parameters with deprecation warning
-        self._warn_deprecated_parameters(spacy_model, transformer_model)
-
-        # Set up recognizer
-        if recognizer is _UNSET:
-            # No recognizer provided, create default
-            from geoparser.modules import SpacyRecognizer
-
-            if spacy_model is not None:
-                self.recognizer = SpacyRecognizer(model_name=spacy_model)
-            else:
-                self.recognizer = SpacyRecognizer()
-        else:
-            # Recognizer explicitly provided (could be None to skip)
-            self.recognizer = recognizer
-
-        # Set up resolver
-        if resolver is _UNSET:
-            # No resolver provided, create default
-            from geoparser.modules import SentenceTransformerResolver
-
-            if transformer_model is not None:
-                self.resolver = SentenceTransformerResolver(
-                    model_name=transformer_model
-                )
-            else:
-                self.resolver = SentenceTransformerResolver()
-        else:
-            # Resolver explicitly provided (could be None to skip)
-            self.resolver = resolver
-
-    @staticmethod
-    def _warn_deprecated_parameters(
-        spacy_model: Optional[str], transformer_model: Optional[str]
-    ) -> None:
-        """
-        Show deprecation warning for legacy parameters.
-
-        Args:
-            spacy_model: Legacy spacy_model parameter value
-            transformer_model: Legacy transformer_model parameter value
-        """
-        # Collect all legacy parameters used
-        legacy_params = []
-        if spacy_model is not None:
-            legacy_params.append(
-                ("spacy_model", spacy_model, "SpacyRecognizer", "recognizer")
-            )
-        if transformer_model is not None:
-            legacy_params.append(
-                (
-                    "transformer_model",
-                    transformer_model,
-                    "SentenceTransformerResolver",
-                    "resolver",
-                )
-            )
-
-        # Show a single consolidated warning if any legacy parameters are used
-        if not legacy_params:
-            return
-
-        # List the deprecated parameters
-        param_names = ", ".join([f"'{param}'" for param, _, _, _ in legacy_params])
-        warning_parts = [
-            f"Deprecated parameter{'s' if len(legacy_params) > 1 else ''} detected: {param_names}. "
-            "The Geoparser now uses a module-based architecture "
-            "where you create and configure recognizer and resolver modules explicitly.\n"
-        ]
-
-        # Build the old usage example
-        old_params = ",\n        ".join(
-            [f"{param}='{value}'" for param, value, _, _ in legacy_params]
-        )
-
-        warning_parts.append("Instead of:")
-        warning_parts.append(f"    Geoparser(\n        {old_params}\n    )\n")
-
-        # Build the new usage example
-        warning_parts.append("Please use:")
-        imports = [f"{module_class}" for _, _, module_class, _ in legacy_params]
-        warning_parts.append(
-            f"    from geoparser.modules import {', '.join(imports)}\n"
-        )
-
-        new_params = ",\n        ".join(
-            [
-                f"{arg_name}={module_class}(model_name='{value}')"
-                for _, value, module_class, arg_name in legacy_params
-            ]
-        )
-        warning_parts.append(f"    Geoparser(\n        {new_params}\n    )\n\n")
-
-        # Use simplefilter to control how the warning is displayed
-        with warnings.catch_warnings():
-            warnings.simplefilter("always", DeprecationWarning)
-            warnings.warn("\n".join(warning_parts), DeprecationWarning, stacklevel=3)
+        self.recognizer = recognizer
+        self.resolver = resolver
 
     def parse(self, texts: Union[str, List[str]], save: bool = False) -> List[Document]:
         """

--- a/geoparser/geoparser/geoparser.py
+++ b/geoparser/geoparser/geoparser.py
@@ -154,7 +154,8 @@ class Geoparser:
 
         Returns:
             List of Document objects with processed references and referents
-            from the configured recognizer and resolver.
+            from the configured recognizer and resolver, in the same order as
+            the texts that were passed in.
         """
         # Create a new project for this parse operation
         project_name = uuid.uuid4().hex[:8]
@@ -162,7 +163,7 @@ class Geoparser:
 
         try:
             # Create documents in the project
-            project.create_documents(texts)
+            document_ids = project.create_documents(texts)
 
             # Run the recognizer on all documents (if provided)
             if self.recognizer is not None:
@@ -172,8 +173,9 @@ class Geoparser:
             if self.resolver is not None:
                 project.run_resolver(self.resolver)
 
-            # Get all documents with results from our specific recognizer and resolver
-            documents = project.get_documents()
+            # Get the documents back in input order, with results from our
+            # specific recognizer and resolver
+            documents = project.get_documents(ids=document_ids)
 
             # If save is True, inform the user about the project name
             if save:

--- a/geoparser/geoparser/geoparser.py
+++ b/geoparser/geoparser/geoparser.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import List, Optional, Union
+from typing import List, Optional, Sequence, Union, overload
 
 from geoparser.db.models import Document
 from geoparser.modules.recognizers import Recognizer
@@ -43,31 +43,47 @@ class Geoparser:
         self.recognizer = recognizer
         self.resolver = resolver
 
-    def parse(self, texts: Union[str, List[str]], save: bool = False) -> List[Document]:
+    @overload
+    def parse(self, texts: str, save: bool = False) -> Document: ...
+
+    @overload
+    def parse(self, texts: Sequence[str], save: bool = False) -> List[Document]: ...
+
+    def parse(
+        self, texts: Union[str, Sequence[str]], save: bool = False
+    ) -> Union[Document, List[Document]]:
         """
         Parse one or more texts with the configured recognizer and resolver.
+
+        The result mirrors the input: a single text is parsed into a single
+        document, while a sequence of texts is parsed into a list of documents
+        in the same order as the texts that were passed in.
 
         This method creates a new project for each parse operation, processes the texts,
         and returns the results. By default, the project is deleted after processing
         to keep the parse method stateless.
 
         Args:
-            texts: Either a single document text or a list of texts
+            texts: Either a single document text or a sequence of texts
             save: If True, preserve the project after processing. If False (default),
                   delete the project to maintain stateless behavior.
 
         Returns:
-            List of Document objects with processed references and referents
-            from the configured recognizer and resolver, in the same order as
-            the texts that were passed in.
+            A single Document if a single text was passed, or a list of Documents
+            if a sequence of texts was passed, with processed references and
+            referents from the configured recognizer and resolver.
         """
+        # A single text is parsed into a single document, so remember which
+        # shape was asked for before normalizing the input
+        single_text = isinstance(texts, str)
+
         # Create a new project for this parse operation
         project_name = uuid.uuid4().hex[:8]
         project = Project(project_name)
 
         try:
             # Create documents in the project
-            document_ids = project.create_documents(texts)
+            document_ids = project.create_documents([texts] if single_text else texts)
 
             # Run the recognizer on all documents (if provided)
             if self.recognizer is not None:
@@ -85,7 +101,7 @@ class Geoparser:
             if save:
                 print(f"Results saved under project name: {project_name}")
 
-            return documents
+            return documents[0] if single_text else documents
 
         finally:
             # Clean up the project unless the user wants to save it

--- a/geoparser/modules/resolvers/sentencetransformer.py
+++ b/geoparser/modules/resolvers/sentencetransformer.py
@@ -99,15 +99,16 @@ class SentenceTransformerResolver(Resolver):
             gazetteer_name, attribute_map
         )
 
+        # Initialize gazetteer first, so that a missing one is reported before
+        # any time is spent loading models
+        self.gazetteer = Gazetteer(gazetteer_name)
+
         # Initialize transformer and tokenizer
         self.transformer = SentenceTransformer(model_name)
         self.tokenizer = AutoTokenizer.from_pretrained(model_name)
 
         # Initialize spaCy model for sentence splitting
         self.nlp = self._load_spacy_model("xx_sent_ud_sm")
-
-        # Initialize gazetteer
-        self.gazetteer = Gazetteer(gazetteer_name)
 
         # Caches for document processing to avoid recomputation
         self.doc_tokens: Dict[str, int] = {}  # text -> token count

--- a/geoparser/project/project.py
+++ b/geoparser/project/project.py
@@ -64,7 +64,7 @@ class Project:
 
             return project_record.id
 
-    def create_documents(self, texts: Union[str, List[str]]) -> List[uuid.UUID]:
+    def create_documents(self, texts: t.Sequence[str]) -> List[uuid.UUID]:
         """
         Create documents in the project.
 
@@ -74,14 +74,23 @@ class Project:
         to retrieve results for specific documents later on.
 
         Args:
-            texts: Either a single document text or a list of document texts
+            texts: Document texts to create. A single document is created by
+                   passing a sequence with one text in it.
 
         Returns:
             IDs of the created documents, in the order the texts were provided
+
+        Raises:
+            TypeError: If a single text is passed instead of a sequence of texts
         """
-        # Convert single string to list for uniform processing
+        # A bare string would be iterated character by character, creating one
+        # document per character, so reject it instead of doing that silently
         if isinstance(texts, str):
-            texts = [texts]
+            raise TypeError(
+                "create_documents() expects a sequence of texts. To create a single "
+                "document, pass a sequence with one text in it: "
+                "create_documents(['...'])."
+            )
 
         document_ids = []
 

--- a/geoparser/project/project.py
+++ b/geoparser/project/project.py
@@ -64,21 +64,34 @@ class Project:
 
             return project_record.id
 
-    def create_documents(self, texts: Union[str, List[str]]) -> None:
+    def create_documents(self, texts: Union[str, List[str]]) -> List[uuid.UUID]:
         """
         Create documents in the project.
 
+        The returned IDs are in the same order as the texts that were passed in,
+        which lets you relate documents back to whatever they came from. Keep
+        them alongside your own records and pass them to :meth:`get_documents`
+        to retrieve results for specific documents later on.
+
         Args:
             texts: Either a single document text or a list of document texts
+
+        Returns:
+            IDs of the created documents, in the order the texts were provided
         """
         # Convert single string to list for uniform processing
         if isinstance(texts, str):
             texts = [texts]
 
+        document_ids = []
+
         with get_session() as session:
             for text in texts:
                 document_create = DocumentCreate(text=text, project_id=self.id)
-                DocumentRepository.create(session, document_create)
+                document = DocumentRepository.create(session, document_create)
+                document_ids.append(document.id)
+
+        return document_ids
 
     def create_references(
         self, texts: List[str], references: List[List[tuple]], tag: str
@@ -115,24 +128,93 @@ class Project:
         )
         self.run_resolver(resolver, tag=tag)
 
-    def get_documents(self, tag: str = "latest") -> List[Document]:
+    @staticmethod
+    def _normalize_document_ids(
+        ids: Union[uuid.UUID, str, t.Sequence[Union[uuid.UUID, str]]],
+    ) -> List[uuid.UUID]:
         """
-        Retrieve all documents in the project with context set for the specified tag.
+        Convert document IDs given as UUIDs or strings into a list of UUIDs.
 
         Args:
+            ids: A single document ID or a sequence of document IDs
+
+        Returns:
+            List of document IDs as UUID objects
+
+        Raises:
+            ValueError: If a value cannot be interpreted as a document ID
+        """
+        # A single ID is accepted as well as a sequence of them
+        if isinstance(ids, (str, uuid.UUID)):
+            ids = [ids]
+
+        normalized = []
+        for value in ids:
+            if isinstance(value, uuid.UUID):
+                normalized.append(value)
+                continue
+            try:
+                normalized.append(uuid.UUID(str(value)))
+            except (AttributeError, TypeError, ValueError):
+                raise ValueError(
+                    f"'{value}' is not a valid document ID. Document IDs are the values "
+                    "returned by create_documents(). To select results by tag instead, "
+                    "pass the tag as a keyword argument: get_documents(tag='...')."
+                ) from None
+
+        return normalized
+
+    def get_documents(
+        self,
+        ids: t.Optional[
+            Union[uuid.UUID, str, t.Sequence[Union[uuid.UUID, str]]]
+        ] = None,
+        tag: str = "latest",
+    ) -> List[Document]:
+        """
+        Retrieve documents in the project with context set for the specified tag.
+
+        Args:
+            ids: Document IDs to retrieve, as returned by :meth:`create_documents`.
+                 The documents are returned in the order given here. If omitted,
+                 every document in the project is returned.
             tag: Tag identifier to determine which recognizer/resolver context to use
                  (default: "latest")
 
         Returns:
             List of Document objects with context set for filtering.
+
+        Raises:
+            ValueError: If an ID does not belong to a document in this project
         """
+        # Validate the requested IDs before touching the database
+        requested_ids = None if ids is None else self._normalize_document_ids(ids)
+
         # Retrieve recognizer and resolver IDs for the specified tag
         recognizer_id = self.context.get_recognizer_context(tag)
         resolver_id = self.context.get_resolver_context(tag)
 
         with get_session() as session:
-            # Retrieve all documents for the project
-            documents = DocumentRepository.get_by_project(session, self.id)
+            if requested_ids is None:
+                # Retrieve all documents for the project
+                documents = DocumentRepository.get_by_project(session, self.id)
+            else:
+                # Retrieve the requested documents in the order they were requested
+                found = {
+                    document.id: document
+                    for document in DocumentRepository.get_by_ids(
+                        session, self.id, requested_ids
+                    )
+                }
+
+                missing = [str(id) for id in requested_ids if id not in found]
+                if missing:
+                    raise ValueError(
+                        f"No documents with the following IDs exist in project "
+                        f"'{self.name}': {', '.join(missing)}"
+                    )
+
+                documents = [found[id] for id in requested_ids]
 
             # Always set context on each document (even if None)
             for doc in documents:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ include = [
     "LICENSE",
     "THIRD_PARTY_LICENSES",
     "README.md",
+    "ROADMAP.md",
 ]
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ exclude_also = [
     "raise AssertionError",
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
+    "@(t\\.|typing\\.)?overload",
     "if t.TYPE_CHECKING:",
     ]
 

--- a/tests/integration/test_project_integration.py
+++ b/tests/integration/test_project_integration.py
@@ -61,6 +61,50 @@ class TestProjectIntegration:
         # Cleanup
         project.delete()
 
+    def test_create_documents_returns_ids_that_identify_documents(self):
+        """Test that the returned IDs can be used to retrieve specific documents."""
+        # Arrange
+        project = Project("doc_id_test_project")
+        texts = ["First document.", "Second document.", "Third document."]
+
+        # Act
+        document_ids = project.create_documents(texts)
+
+        # Assert - IDs come back in input order and select documents in any order
+        assert len(document_ids) == 3
+
+        documents = project.get_documents(ids=document_ids)
+        assert [document.text for document in documents] == texts
+
+        selected = project.get_documents(ids=[document_ids[2], document_ids[0]])
+        assert [document.text for document in selected] == [
+            "Third document.",
+            "First document.",
+        ]
+
+        single = project.get_documents(ids=document_ids[1])
+        assert [document.text for document in single] == ["Second document."]
+
+        # Cleanup
+        project.delete()
+
+    def test_get_documents_rejects_id_from_another_project(self):
+        """Test that documents of other projects cannot be retrieved by ID."""
+        # Arrange
+        other_project = Project("other_doc_id_project")
+        other_ids = other_project.create_documents(["Someone else's document."])
+
+        project = Project("doc_id_isolation_project")
+        project.create_documents(["My document."])
+
+        # Act & Assert
+        with pytest.raises(ValueError, match=str(other_ids[0])):
+            project.get_documents(ids=other_ids)
+
+        # Cleanup
+        project.delete()
+        other_project.delete()
+
     def test_run_recognizer_creates_references(self):
         """Test that run_recognizer creates reference records."""
         # Arrange

--- a/tests/unit/test_geoparser/test_geoparser.py
+++ b/tests/unit/test_geoparser/test_geoparser.py
@@ -4,6 +4,7 @@ Unit tests for geoparser/geoparser/geoparser.py
 Tests the Geoparser class with mocked dependencies.
 """
 
+import uuid
 from unittest.mock import Mock, patch
 
 import pytest
@@ -235,26 +236,27 @@ class TestGeoparserParse:
         mock_project_instance.run_resolver.assert_called_once_with(mock_resolver)
 
     @patch("geoparser.geoparser.geoparser.Project")
-    def test_retrieves_documents_with_default_tag(self, mock_project_class):
-        """Test that parse retrieves documents using the default 'latest' tag."""
+    def test_retrieves_documents_by_created_ids(self, mock_project_class):
+        """Test that parse retrieves the documents it created, in input order."""
         # Arrange
         mock_recognizer = Mock()
         mock_recognizer.id = "test_rec_id"
         mock_resolver = Mock()
         mock_resolver.id = "test_res_id"
 
+        document_ids = [uuid.uuid4(), uuid.uuid4()]
         mock_project_instance = Mock()
+        mock_project_instance.create_documents.return_value = document_ids
         mock_project_instance.get_documents.return_value = []
         mock_project_class.return_value = mock_project_instance
 
         geoparser = Geoparser(mock_recognizer, mock_resolver)
 
         # Act
-        geoparser.parse("Test text")
+        geoparser.parse(["Text 1", "Text 2"])
 
         # Assert
-        # get_documents is called with default tag parameter
-        mock_project_instance.get_documents.assert_called_once_with()
+        mock_project_instance.get_documents.assert_called_once_with(ids=document_ids)
 
     @patch("geoparser.geoparser.geoparser.Project")
     def test_deletes_project_after_parsing_by_default(self, mock_project_class):

--- a/tests/unit/test_geoparser/test_geoparser.py
+++ b/tests/unit/test_geoparser/test_geoparser.py
@@ -80,7 +80,7 @@ class TestGeoparserParse:
         mock_resolver.id = "test_res"
 
         mock_project_instance = Mock()
-        mock_project_instance.get_documents.return_value = []
+        mock_project_instance.get_documents.return_value = [Mock()]
         mock_project_class.return_value = mock_project_instance
 
         geoparser = Geoparser(mock_recognizer, mock_resolver)
@@ -105,7 +105,7 @@ class TestGeoparserParse:
         mock_resolver.id = "test_res"
 
         mock_project_instance = Mock()
-        mock_project_instance.get_documents.return_value = []
+        mock_project_instance.get_documents.return_value = [Mock()]
         mock_project_class.return_value = mock_project_instance
 
         geoparser = Geoparser(mock_recognizer, mock_resolver)
@@ -114,7 +114,7 @@ class TestGeoparserParse:
         geoparser.parse("Test text")
 
         # Assert
-        mock_project_instance.create_documents.assert_called_once_with("Test text")
+        mock_project_instance.create_documents.assert_called_once_with(["Test text"])
 
     @patch("geoparser.geoparser.geoparser.Project")
     def test_runs_recognizer_on_documents(self, mock_project_class):
@@ -126,7 +126,7 @@ class TestGeoparserParse:
         mock_resolver.id = "test_res"
 
         mock_project_instance = Mock()
-        mock_project_instance.get_documents.return_value = []
+        mock_project_instance.get_documents.return_value = [Mock()]
         mock_project_class.return_value = mock_project_instance
 
         geoparser = Geoparser(mock_recognizer, mock_resolver)
@@ -147,7 +147,7 @@ class TestGeoparserParse:
         mock_resolver.id = "test_res"
 
         mock_project_instance = Mock()
-        mock_project_instance.get_documents.return_value = []
+        mock_project_instance.get_documents.return_value = [Mock()]
         mock_project_class.return_value = mock_project_instance
 
         geoparser = Geoparser(mock_recognizer, mock_resolver)
@@ -191,7 +191,7 @@ class TestGeoparserParse:
         mock_resolver.id = "test_res"
 
         mock_project_instance = Mock()
-        mock_project_instance.get_documents.return_value = []
+        mock_project_instance.get_documents.return_value = [Mock()]
         mock_project_class.return_value = mock_project_instance
 
         geoparser = Geoparser(mock_recognizer, mock_resolver)
@@ -212,7 +212,7 @@ class TestGeoparserParse:
         mock_resolver.id = "test_res"
 
         mock_project_instance = Mock()
-        mock_project_instance.get_documents.return_value = []
+        mock_project_instance.get_documents.return_value = [Mock()]
         mock_project_class.return_value = mock_project_instance
 
         geoparser = Geoparser(mock_recognizer, mock_resolver)
@@ -224,8 +224,30 @@ class TestGeoparserParse:
         mock_project_instance.delete.assert_not_called()
 
     @patch("geoparser.geoparser.geoparser.Project")
-    def test_returns_processed_documents(self, mock_project_class):
-        """Test that parse returns the processed documents."""
+    def test_returns_single_document_for_a_single_text(self, mock_project_class):
+        """Test that parse returns one document when given a single text."""
+        # Arrange
+        mock_recognizer = Mock()
+        mock_recognizer.id = "test_rec"
+        mock_resolver = Mock()
+        mock_resolver.id = "test_res"
+
+        mock_doc = Mock()
+        mock_project_instance = Mock()
+        mock_project_instance.get_documents.return_value = [mock_doc]
+        mock_project_class.return_value = mock_project_instance
+
+        geoparser = Geoparser(mock_recognizer, mock_resolver)
+
+        # Act
+        result = geoparser.parse("Test text")
+
+        # Assert
+        assert result == mock_doc
+
+    @patch("geoparser.geoparser.geoparser.Project")
+    def test_returns_list_of_documents_for_a_list_of_texts(self, mock_project_class):
+        """Test that parse returns a list of documents when given a list of texts."""
         # Arrange
         mock_recognizer = Mock()
         mock_recognizer.id = "test_rec"
@@ -241,12 +263,32 @@ class TestGeoparserParse:
         geoparser = Geoparser(mock_recognizer, mock_resolver)
 
         # Act
-        result = geoparser.parse("Test text")
+        result = geoparser.parse(["Text 1", "Text 2"])
 
         # Assert
-        assert len(result) == 2
-        assert result[0] == mock_doc1
-        assert result[1] == mock_doc2
+        assert result == [mock_doc1, mock_doc2]
+
+    @patch("geoparser.geoparser.geoparser.Project")
+    def test_returns_list_for_a_single_text_in_a_list(self, mock_project_class):
+        """Test that the result shape follows the input container, not its length."""
+        # Arrange
+        mock_recognizer = Mock()
+        mock_recognizer.id = "test_rec"
+        mock_resolver = Mock()
+        mock_resolver.id = "test_res"
+
+        mock_doc = Mock()
+        mock_project_instance = Mock()
+        mock_project_instance.get_documents.return_value = [mock_doc]
+        mock_project_class.return_value = mock_project_instance
+
+        geoparser = Geoparser(mock_recognizer, mock_resolver)
+
+        # Act
+        result = geoparser.parse(["Test text"])
+
+        # Assert
+        assert result == [mock_doc]
 
     @patch("geoparser.geoparser.geoparser.Project")
     def test_handles_list_of_texts(self, mock_project_class):
@@ -282,7 +324,7 @@ class TestGeoparserParse:
         mock_resolver.id = "test_res"
 
         mock_project_instance = Mock()
-        mock_project_instance.get_documents.return_value = []
+        mock_project_instance.get_documents.return_value = [Mock()]
         mock_project_class.return_value = mock_project_instance
 
         geoparser = Geoparser(mock_recognizer, mock_resolver)

--- a/tests/unit/test_geoparser/test_geoparser.py
+++ b/tests/unit/test_geoparser/test_geoparser.py
@@ -29,26 +29,17 @@ class TestGeoparserInitialization:
         assert geoparser.recognizer == mock_recognizer
         assert geoparser.resolver == mock_resolver
 
-    @patch("geoparser.modules.SpacyRecognizer")
-    @patch("geoparser.modules.SentenceTransformerResolver")
-    def test_creates_default_modules_when_none_provided(
-        self, mock_resolver_class, mock_recognizer_class
-    ):
-        """Test that Geoparser creates default modules when none are provided."""
-        # Arrange
-        mock_recognizer_instance = Mock()
-        mock_resolver_instance = Mock()
-        mock_recognizer_class.return_value = mock_recognizer_instance
-        mock_resolver_class.return_value = mock_resolver_instance
+    def test_requires_recognizer_and_resolver(self):
+        """Test that Geoparser cannot be created without modules."""
+        # Act & Assert
+        with pytest.raises(TypeError):
+            Geoparser()
 
-        # Act
-        geoparser = Geoparser()
-
-        # Assert
-        mock_recognizer_class.assert_called_once_with()
-        mock_resolver_class.assert_called_once_with()
-        assert geoparser.recognizer == mock_recognizer_instance
-        assert geoparser.resolver == mock_resolver_instance
+    def test_requires_resolver(self):
+        """Test that Geoparser cannot be created with a recognizer alone."""
+        # Act & Assert
+        with pytest.raises(TypeError):
+            Geoparser(Mock())
 
     def test_accepts_none_for_recognizer(self):
         """Test that Geoparser accepts None for recognizer to skip recognition."""
@@ -73,74 +64,6 @@ class TestGeoparserInitialization:
         # Assert
         assert geoparser.recognizer == mock_recognizer
         assert geoparser.resolver is None
-
-    @patch("geoparser.modules.SpacyRecognizer")
-    def test_legacy_spacy_model_parameter_shows_deprecation_warning(
-        self, mock_recognizer_class
-    ):
-        """Test that using spacy_model parameter shows deprecation warning."""
-        # Arrange
-        mock_recognizer_instance = Mock()
-        mock_recognizer_class.return_value = mock_recognizer_instance
-        mock_resolver = Mock()
-
-        # Act & Assert
-        with pytest.warns(DeprecationWarning, match="Deprecated parameter detected"):
-            geoparser = Geoparser(resolver=mock_resolver, spacy_model="en_core_web_sm")
-
-        # Should still create recognizer with the model
-        mock_recognizer_class.assert_called_once_with(model_name="en_core_web_sm")
-        assert geoparser.recognizer == mock_recognizer_instance
-
-    @patch("geoparser.modules.SentenceTransformerResolver")
-    def test_legacy_transformer_model_parameter_shows_deprecation_warning(
-        self, mock_resolver_class
-    ):
-        """Test that using transformer_model parameter shows deprecation warning."""
-        # Arrange
-        mock_resolver_instance = Mock()
-        mock_resolver_class.return_value = mock_resolver_instance
-        mock_recognizer = Mock()
-
-        # Act & Assert
-        with pytest.warns(DeprecationWarning, match="Deprecated parameter detected"):
-            geoparser = Geoparser(
-                recognizer=mock_recognizer,
-                transformer_model="dguzh/geo-all-MiniLM-L6-v2",
-            )
-
-        # Should still create resolver with the model
-        mock_resolver_class.assert_called_once_with(
-            model_name="dguzh/geo-all-MiniLM-L6-v2"
-        )
-        assert geoparser.resolver == mock_resolver_instance
-
-    @patch("geoparser.modules.SpacyRecognizer")
-    @patch("geoparser.modules.SentenceTransformerResolver")
-    def test_legacy_parameters_show_single_consolidated_warning(
-        self, mock_resolver_class, mock_recognizer_class
-    ):
-        """Test that using both legacy parameters shows single consolidated warning."""
-        # Arrange
-        mock_recognizer_instance = Mock()
-        mock_resolver_instance = Mock()
-        mock_recognizer_class.return_value = mock_recognizer_instance
-        mock_resolver_class.return_value = mock_resolver_instance
-
-        # Act & Assert
-        with pytest.warns(DeprecationWarning, match="Deprecated parameters detected"):
-            geoparser = Geoparser(
-                spacy_model="en_core_web_sm",
-                transformer_model="dguzh/geo-all-MiniLM-L6-v2",
-            )
-
-        # Should create both with the specified models
-        mock_recognizer_class.assert_called_once_with(model_name="en_core_web_sm")
-        mock_resolver_class.assert_called_once_with(
-            model_name="dguzh/geo-all-MiniLM-L6-v2"
-        )
-        assert geoparser.recognizer == mock_recognizer_instance
-        assert geoparser.resolver == mock_resolver_instance
 
 
 @pytest.mark.unit

--- a/tests/unit/test_project/test_project.py
+++ b/tests/unit/test_project/test_project.py
@@ -5,7 +5,7 @@ Tests the Project class with mocked dependencies.
 """
 
 from unittest.mock import ANY, Mock, patch
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -100,6 +100,144 @@ class TestProjectCreateDocuments:
         assert "Doc 1" in call_args_list
         assert "Doc 2" in call_args_list
         assert "Doc 3" in call_args_list
+
+    @patch("geoparser.project.project.ProjectRepository")
+    @patch("geoparser.project.project.DocumentRepository")
+    def test_returns_document_ids_in_input_order(
+        self, mock_doc_repo, mock_project_repo
+    ):
+        """Test that create_documents returns the new IDs in the order of the texts."""
+        # Arrange
+
+        mock_existing_project = Mock()
+        mock_existing_project.id = UUID("12345678-1234-5678-1234-567812345678")
+        mock_project_repo.get_by_name.return_value = mock_existing_project
+
+        created_ids = [uuid4(), uuid4(), uuid4()]
+        mock_doc_repo.create.side_effect = [Mock(id=id) for id in created_ids]
+
+        project = Project("TestProject")
+
+        # Act
+        document_ids = project.create_documents(["Doc 1", "Doc 2", "Doc 3"])
+
+        # Assert
+        assert document_ids == created_ids
+
+
+@pytest.mark.unit
+class TestProjectGetDocumentsByIds:
+    """Test Project get_documents method when specific IDs are requested."""
+
+    @patch("geoparser.project.project.Context")
+    @patch("geoparser.project.project.ProjectRepository")
+    @patch("geoparser.project.project.DocumentRepository")
+    def test_returns_documents_in_requested_order(
+        self, mock_doc_repo, mock_project_repo, mock_context
+    ):
+        """Test that get_documents returns documents in the order the IDs were given."""
+        # Arrange
+
+        mock_existing_project = Mock()
+        mock_existing_project.id = UUID("12345678-1234-5678-1234-567812345678")
+        mock_project_repo.get_by_name.return_value = mock_existing_project
+
+        first_id, second_id = uuid4(), uuid4()
+        mock_doc1 = Mock(id=first_id, references=[])
+        mock_doc2 = Mock(id=second_id, references=[])
+
+        # The repository makes no promises about ordering
+        mock_doc_repo.get_by_ids.return_value = [mock_doc2, mock_doc1]
+
+        mock_context_instance = Mock()
+        mock_context_instance.get_recognizer_context.return_value = None
+        mock_context_instance.get_resolver_context.return_value = None
+        mock_context.return_value = mock_context_instance
+
+        project = Project("TestProject")
+
+        # Act
+        documents = project.get_documents(ids=[first_id, second_id])
+
+        # Assert
+        assert documents == [mock_doc1, mock_doc2]
+        mock_doc_repo.get_by_ids.assert_called_once_with(
+            ANY, project.id, [first_id, second_id]
+        )
+
+    @patch("geoparser.project.project.Context")
+    @patch("geoparser.project.project.ProjectRepository")
+    @patch("geoparser.project.project.DocumentRepository")
+    def test_accepts_ids_as_strings(
+        self, mock_doc_repo, mock_project_repo, mock_context
+    ):
+        """Test that get_documents accepts IDs given as strings."""
+        # Arrange
+
+        mock_existing_project = Mock()
+        mock_existing_project.id = UUID("12345678-1234-5678-1234-567812345678")
+        mock_project_repo.get_by_name.return_value = mock_existing_project
+
+        document_id = uuid4()
+        mock_doc = Mock(id=document_id, references=[])
+        mock_doc_repo.get_by_ids.return_value = [mock_doc]
+
+        mock_context_instance = Mock()
+        mock_context_instance.get_recognizer_context.return_value = None
+        mock_context_instance.get_resolver_context.return_value = None
+        mock_context.return_value = mock_context_instance
+
+        project = Project("TestProject")
+
+        # Act
+        documents = project.get_documents(ids=str(document_id))
+
+        # Assert
+        assert documents == [mock_doc]
+        mock_doc_repo.get_by_ids.assert_called_once_with(ANY, project.id, [document_id])
+
+    @patch("geoparser.project.project.Context")
+    @patch("geoparser.project.project.ProjectRepository")
+    @patch("geoparser.project.project.DocumentRepository")
+    def test_raises_for_unknown_id(
+        self, mock_doc_repo, mock_project_repo, mock_context
+    ):
+        """Test that get_documents raises if an ID is not in the project."""
+        # Arrange
+
+        mock_existing_project = Mock()
+        mock_existing_project.id = UUID("12345678-1234-5678-1234-567812345678")
+        mock_project_repo.get_by_name.return_value = mock_existing_project
+
+        unknown_id = uuid4()
+        mock_doc_repo.get_by_ids.return_value = []
+
+        mock_context_instance = Mock()
+        mock_context_instance.get_recognizer_context.return_value = None
+        mock_context_instance.get_resolver_context.return_value = None
+        mock_context.return_value = mock_context_instance
+
+        project = Project("TestProject")
+
+        # Act & Assert
+        with pytest.raises(ValueError, match=str(unknown_id)):
+            project.get_documents(ids=[unknown_id])
+
+    @patch("geoparser.project.project.ProjectRepository")
+    @patch("geoparser.project.project.DocumentRepository")
+    def test_raises_for_value_that_is_not_an_id(self, mock_doc_repo, mock_project_repo):
+        """Test that a value that isn't an ID is reported with a hint about tags."""
+        # Arrange
+
+        mock_existing_project = Mock()
+        mock_existing_project.id = UUID("12345678-1234-5678-1234-567812345678")
+        mock_project_repo.get_by_name.return_value = mock_existing_project
+
+        project = Project("TestProject")
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="not a valid document ID"):
+            project.get_documents(ids="baseline")
 
 
 @pytest.mark.unit

--- a/tests/unit/test_project/test_project.py
+++ b/tests/unit/test_project/test_project.py
@@ -59,7 +59,7 @@ class TestProjectCreateDocuments:
     @patch("geoparser.project.project.ProjectRepository")
     @patch("geoparser.project.project.DocumentRepository")
     def test_creates_single_document(self, mock_doc_repo, mock_project_repo):
-        """Test that create_documents creates a single document from a string."""
+        """Test that create_documents creates a single document from a one-text list."""
         # Arrange
 
         mock_existing_project = Mock()
@@ -69,13 +69,31 @@ class TestProjectCreateDocuments:
         project = Project("TestProject")
 
         # Act
-        project.create_documents("Test document text")
+        project.create_documents(["Test document text"])
 
         # Assert
         mock_doc_repo.create.assert_called_once()
         call_args = mock_doc_repo.create.call_args[0]
         assert call_args[1].text == "Test document text"
         assert call_args[1].project_id == project.id
+
+    @patch("geoparser.project.project.ProjectRepository")
+    @patch("geoparser.project.project.DocumentRepository")
+    def test_rejects_a_bare_string(self, mock_doc_repo, mock_project_repo):
+        """Test that create_documents rejects a string instead of splitting it up."""
+        # Arrange
+
+        mock_existing_project = Mock()
+        mock_existing_project.id = UUID("12345678-1234-5678-1234-567812345678")
+        mock_project_repo.get_by_name.return_value = mock_existing_project
+
+        project = Project("TestProject")
+
+        # Act & Assert
+        with pytest.raises(TypeError, match="expects a sequence of texts"):
+            project.create_documents("Test document text")
+
+        mock_doc_repo.create.assert_not_called()
 
     @patch("geoparser.project.project.ProjectRepository")
     @patch("geoparser.project.project.DocumentRepository")


### PR DESCRIPTION
This PR addresses three JOSS review items ahead of 0.6.0.

`Geoparser` now requires `recognizer` and `resolver` to be passed explicitly, removing the implicit defaults and the opaque `_UNSET` sentinel from the constructor signature. The deprecated `spacy_model` and `transformer_model` parameters are removed with them. Docs and the README are updated so examples construct modules explicitly. Constructing a resolver against a missing gazetteer already raised after the 0.5.0 redesign; the error message now points at the install command, and the check runs before heavy models are loaded (#91).

`create_documents()` now returns the assigned document IDs in input order, and `get_documents(ids=...)` can retrieve specific documents in a chosen order. That makes it possible to join results back to source material without reprocessing (#95). `Geoparser.parse()` uses the same path so returned documents stay aligned with the input texts. Its return type now also mirrors the input shape: a single text returns a `Document`, while a sequence of texts returns a list of `Document`s. `create_documents()` itself is sequence-only (pass `["..."]` for one document), so its plural name matches its input and return types.

The larger architecture points from the review (#94) are not implemented here, but the intended direction is documented in `ROADMAP.md` (also linked from the docs and README): a lighter core with gazetteer and default modules split out, and a rethink of project/database-centric data handling. Some related groundwork already shipped earlier (SpatiaLite removal in 0.4.0; separate gazetteer artifacts in 0.5.0).