### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,13 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it as below.
+title: 'The Irchel Geoparser: A Modular Python Library for Toponym Recognition and Resolution'
+type: software
+authors:
+- given-names: Diego
+  family-names: Gomes
+  orcid: https://orcid.org/0009-0003-8449-2603
+- given-names: Ross S.
+  family-names: Purves
+  orcid: https://orcid.org/0000-0002-9878-9243
+repository-code: https://github.com/dguzh/geoparser
+license: MIT


### PR DESCRIPTION
Adds a `CITATION.cff` so GitHub shows a "Cite this repository" button and citation tooling can read machine-readable metadata.

Author names and ORCIDs come from `paper.md`, and the licence from the LICENSE file. Validated with `cffconvert --validate` against schema 1.2.0.

Worth checking the given-name/family-name split per author, since some papers give a single `name` field.